### PR TITLE
ImageJVirtualStackFloat: Don't compute minmax

### DIFF
--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackFloat.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackFloat.java
@@ -50,7 +50,7 @@ public class ImageJVirtualStackFloat< S > extends ImageJVirtualStack< S, FloatTy
 	public ImageJVirtualStackFloat( final RandomAccessibleInterval< S > source, final Converter< S, FloatType > converter )
 	{
 		super( source, converter, new FloatType(), ImagePlus.GRAY32 );
-		setMinMax( source, converter );
+		imageProcessor.setMinAndMax( 0, 1 );
 	}
 
 	public void setMinMax ( final RandomAccessibleInterval< S > source, final Converter< S, FloatType > converter )


### PR DESCRIPTION
Avoids iteration of the dataset when creating ImageJVirtualStackFloat instances.