### PR TITLE
Added transformation of BitType into 8-bit ImagePlus

### DIFF
--- a/src/main/java/net/imglib2/img/display/imagej/ImageJFunctions.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJFunctions.java
@@ -53,6 +53,7 @@ import net.imglib2.converter.TypeIdentity;
 import net.imglib2.img.ImagePlusAdapter;
 import net.imglib2.img.Img;
 import net.imglib2.type.NativeType;
+import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.IntegerType;
@@ -163,9 +164,12 @@ public class ImageJFunctions
 		final Object oImg = img;
 		if ( ARGBType.class.isInstance( t ) )
 			target = wrapRGB( ( RandomAccessibleInterval< ARGBType > )oImg, title );
-		else if ( UnsignedByteType.class.isInstance( t ) )
+		else if ( UnsignedByteType.class.isInstance( t ))
 			target = wrapUnsignedByte( ( RandomAccessibleInterval< RealType > )oImg, title );
-		else if ( IntegerType.class.isInstance( t ) )
+                else if ( BitType.class.isInstance( t )) {
+                        target = wrapBit( (RandomAccessibleInterval < RealType > )oImg,title);
+                }
+                else if ( IntegerType.class.isInstance( t ) )
 			target = wrapUnsignedShort( ( RandomAccessibleInterval< RealType > )oImg, title );
 		else if ( RealType.class.isInstance( t ) )
 			target = wrapFloat( ( RandomAccessibleInterval< RealType > )oImg, title );
@@ -360,6 +364,19 @@ public class ImageJFunctions
 	{
 		return wrapUnsignedByte( img, new RealUnsignedByteConverter< T >( 0, 255 ), title );
 	}
+        
+        
+        /**
+	 * Create a single channel 8-bit unsigned integer {@link ImagePlus}
+	 * from a BitType {@link RandomAccessibleInterval} using a custom {@link Converter}.
+	 */
+	public static < T extends RealType< T > > ImagePlus wrapBit(
+			final RandomAccessibleInterval< T > img,
+			final String title )
+	{
+		return wrapUnsignedByte( img, new RealUnsignedByteConverter< T >( 0, 1 ), title );
+	}
+        
 
 	/**
 	 * Create a single channel 8-bit unsigned integer {@link ImagePlus}

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJFunctions.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJFunctions.java
@@ -90,28 +90,58 @@ public class ImageJFunctions
 {
 	final static AtomicInteger ai = new AtomicInteger();
 
-	public static <T extends NumericType<T> & NativeType<T>> Img< T > wrap( final ImagePlus imp ) { return ImagePlusAdapter.wrap( imp ); }
+	public static < T extends NumericType< T > & NativeType< T > > Img< T > wrap( final ImagePlus imp )
+	{
+		return ImagePlusAdapter.wrap( imp );
+	}
 
-	@SuppressWarnings("unchecked")
-	public static < T extends RealType<T> > Img< T > wrapReal( final ImagePlus imp ) { return ImagePlusAdapter.wrapReal( imp ); }
+	@SuppressWarnings( "unchecked" )
+	public static < T extends RealType< T > > Img< T > wrapReal( final ImagePlus imp )
+	{
+		return ImagePlusAdapter.wrapReal( imp );
+	}
 
-	@SuppressWarnings("unchecked")
-	public static < T extends RealType<T> & NativeType<T>> Img< T > wrapRealNative( final ImagePlus imp ) { return ImagePlusAdapter.wrapReal( imp ); }
+	@SuppressWarnings( "unchecked" )
+	public static < T extends RealType< T > & NativeType< T > > Img< T > wrapRealNative( final ImagePlus imp )
+	{
+		return ImagePlusAdapter.wrapReal( imp );
+	}
 
-	@SuppressWarnings("unchecked")
-	public static < T extends NumericType<T> > Img< T > wrapNumeric( final ImagePlus imp ) { return ImagePlusAdapter.wrapNumeric( imp ); }
+	@SuppressWarnings( "unchecked" )
+	public static < T extends NumericType< T > > Img< T > wrapNumeric( final ImagePlus imp )
+	{
+		return ImagePlusAdapter.wrapNumeric( imp );
+	}
 
-	public static < T extends NumericType<T> & NativeType<T>> Img< T > wrapNumericNative( final ImagePlus imp ) { return wrap( imp ); }
+	public static < T extends NumericType< T > & NativeType< T > > Img< T > wrapNumericNative( final ImagePlus imp )
+	{
+		return wrap( imp );
+	}
 
-	public static Img<UnsignedByteType> wrapByte( final ImagePlus imp ) { return ImagePlusAdapter.wrapByte( imp ); }
+	public static Img< UnsignedByteType > wrapByte( final ImagePlus imp )
+	{
+		return ImagePlusAdapter.wrapByte( imp );
+	}
 
-	public static Img<UnsignedShortType> wrapShort( final ImagePlus imp ) { return ImagePlusAdapter.wrapShort( imp ); }
+	public static Img< UnsignedShortType > wrapShort( final ImagePlus imp )
+	{
+		return ImagePlusAdapter.wrapShort( imp );
+	}
 
-	public static Img<ARGBType> wrapRGBA( final ImagePlus imp ) { return ImagePlusAdapter.wrapRGBA( imp ); }
+	public static Img< ARGBType > wrapRGBA( final ImagePlus imp )
+	{
+		return ImagePlusAdapter.wrapRGBA( imp );
+	}
 
-	public static Img<FloatType> wrapFloat( final ImagePlus imp ) { return ImagePlusAdapter.wrapFloat( imp ); }
+	public static Img< FloatType > wrapFloat( final ImagePlus imp )
+	{
+		return ImagePlusAdapter.wrapFloat( imp );
+	}
 
-	public static Img<FloatType> convertFloat( final ImagePlus imp ) { return ImagePlusAdapter.convertFloat( imp ); }
+	public static Img< FloatType > convertFloat( final ImagePlus imp )
+	{
+		return ImagePlusAdapter.convertFloat( imp );
+	}
 
 	/**
 	 * Display and return a single channel {@link ImagePlus}, wrapping a
@@ -120,23 +150,25 @@ public class ImageJFunctions
 	 * or ImagePlus.COLOR_RGB) is inferred from the generic type of the input
 	 * {@link RandomAccessibleInterval}.
 	 */
-	public static <T extends NumericType<T>> ImagePlus show( final RandomAccessibleInterval<T> img )
+	public static < T extends NumericType< T > > ImagePlus show( final RandomAccessibleInterval< T > img )
 	{
 		return show( img, "Image " + ai.getAndIncrement() );
 	}
 
 	/**
-	 * Displays a complex type as power spectrum, phase spectrum, real values or imaginary values depending on the converter
+	 * Displays a complex type as power spectrum, phase spectrum, real values or
+	 * imaginary values depending on the converter
 	 */
-	public static <T extends ComplexType<T>> ImagePlus show( final RandomAccessibleInterval<T> img, final Converter< T, FloatType > converter )
+	public static < T extends ComplexType< T > > ImagePlus show( final RandomAccessibleInterval< T > img, final Converter< T, FloatType > converter )
 	{
 		return show( img, converter, "Complex image " + ai.getAndIncrement() );
 	}
 
 	/**
-	 * Displays a complex type as power spectrum, phase spectrum, real values or imaginary values depending on the converter
+	 * Displays a complex type as power spectrum, phase spectrum, real values or
+	 * imaginary values depending on the converter
 	 */
-	public static <T extends ComplexType<T>> ImagePlus show( final RandomAccessibleInterval<T> img, final Converter< T, FloatType > converter, final String title )
+	public static < T extends ComplexType< T > > ImagePlus show( final RandomAccessibleInterval< T > img, final Converter< T, FloatType > converter, final String title )
 	{
 		final ImageJVirtualStackFloat< T > stack = new ImageJVirtualStackFloat< T >( img, converter );
 		final ImagePlus imp = new ImagePlus( title, stack );
@@ -152,7 +184,7 @@ public class ImageJFunctions
 	 * or ImagePlus.COLOR_RGB) is inferred from the generic type of the input
 	 * {@link RandomAccessibleInterval}.
 	 */
-	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@SuppressWarnings( { "unchecked", "rawtypes" } )
 	public static < T extends NumericType< T > > ImagePlus wrap( final RandomAccessibleInterval< T > img, final String title )
 	{
 		ImagePlus target;
@@ -163,53 +195,60 @@ public class ImageJFunctions
 		// TODO: remove casting madness as soon as the bug is fixed
 		final Object oImg = img;
 		if ( ARGBType.class.isInstance( t ) )
-			target = wrapRGB( ( RandomAccessibleInterval< ARGBType > )oImg, title );
-		else if ( UnsignedByteType.class.isInstance( t ))
-			target = wrapUnsignedByte( ( RandomAccessibleInterval< RealType > )oImg, title );
-                else if ( BitType.class.isInstance( t )) {
-                        target = wrapBit( (RandomAccessibleInterval < RealType > )oImg,title);
-                }
-                else if ( IntegerType.class.isInstance( t ) )
-			target = wrapUnsignedShort( ( RandomAccessibleInterval< RealType > )oImg, title );
+			target = wrapRGB( ( RandomAccessibleInterval< ARGBType > ) oImg, title );
+		else if ( UnsignedByteType.class.isInstance( t ) )
+			target = wrapUnsignedByte( ( RandomAccessibleInterval< RealType > ) oImg, title );
+		else if ( BitType.class.isInstance( t ) )
+		{
+			target = wrapBit( ( RandomAccessibleInterval< RealType > ) oImg, title );
+		}
+		else if ( IntegerType.class.isInstance( t ) )
+			target = wrapUnsignedShort( ( RandomAccessibleInterval< RealType > ) oImg, title );
 		else if ( RealType.class.isInstance( t ) )
-			target = wrapFloat( ( RandomAccessibleInterval< RealType > )oImg, title );
+			target = wrapFloat( ( RandomAccessibleInterval< RealType > ) oImg, title );
 		else if ( ComplexType.class.isInstance( t ) )
-			target = wrapFloat( ( RandomAccessibleInterval< ComplexType > )oImg, new ComplexPowerGLogFloatConverter(), title );
+			target = wrapFloat( ( RandomAccessibleInterval< ComplexType > ) oImg, new ComplexPowerGLogFloatConverter(), title );
 		else
 		{
 			System.out.println( "Do not know how to display Type " + t.getClass().getSimpleName() );
 			target = null;
 		}
 
-		// Retrieve and set calibration if we can. ImgPlus has calibration and axis types
-		if (null != target && img instanceof ImgPlus) {
+		// Retrieve and set calibration if we can. ImgPlus has calibration and
+		// axis types
+		if ( null != target && img instanceof ImgPlus )
+		{
 
-			final ImgPlus<T> imgplus = (ImgPlus<T>) img;
+			final ImgPlus< T > imgplus = ( ImgPlus< T > ) img;
 			final Calibration impcal = target.getCalibration();
 
 			// TODO - using averageScale() introduces error for nonlinear axes
 
-			final int xaxis = imgplus.dimensionIndex(Axes.X);
-			if (xaxis >= 0) {
-				impcal.pixelWidth = imgplus.averageScale(xaxis);
-				impcal.xOrigin = imgplus.axis(xaxis).calibratedValue(0);
+			final int xaxis = imgplus.dimensionIndex( Axes.X );
+			if ( xaxis >= 0 )
+			{
+				impcal.pixelWidth = imgplus.averageScale( xaxis );
+				impcal.xOrigin = imgplus.axis( xaxis ).calibratedValue( 0 );
 			}
 
-			final int yaxis = imgplus.dimensionIndex(Axes.Y);
-			if (yaxis >= 0) {
-				impcal.pixelHeight = imgplus.averageScale(yaxis);
-				impcal.yOrigin = imgplus.axis(yaxis).calibratedValue(0);
+			final int yaxis = imgplus.dimensionIndex( Axes.Y );
+			if ( yaxis >= 0 )
+			{
+				impcal.pixelHeight = imgplus.averageScale( yaxis );
+				impcal.yOrigin = imgplus.axis( yaxis ).calibratedValue( 0 );
 			}
 
-			final int zaxis = imgplus.dimensionIndex(Axes.Z);
-			if (zaxis >= 0) {
-				impcal.pixelDepth = imgplus.averageScale(zaxis);
-				impcal.zOrigin = imgplus.axis(zaxis).calibratedValue(0);
+			final int zaxis = imgplus.dimensionIndex( Axes.Z );
+			if ( zaxis >= 0 )
+			{
+				impcal.pixelDepth = imgplus.averageScale( zaxis );
+				impcal.zOrigin = imgplus.axis( zaxis ).calibratedValue( 0 );
 			}
 
-			final int taxis = imgplus.dimensionIndex(Axes.TIME);
-			if (taxis >= 0) {
-				impcal.frameInterval = imgplus.averageScale(taxis);
+			final int taxis = imgplus.dimensionIndex( Axes.TIME );
+			if ( taxis >= 0 )
+			{
+				impcal.frameInterval = imgplus.averageScale( taxis );
 			}
 			target.setTitle( imgplus.getName() );
 		}
@@ -217,15 +256,10 @@ public class ImageJFunctions
 		return target;
 	}
 
-
-
 	public static < T extends NumericType< T > > ImagePlus show( final RandomAccessibleInterval< T > img, final String title )
 	{
 		final ImagePlus imp = wrap( img, title );
-		if ( null == imp )
-		{
-			return null;
-		}
+		if ( null == imp ) { return null; }
 
 		imp.show();
 		imp.getProcessor().resetMinAndMax();
@@ -235,8 +269,8 @@ public class ImageJFunctions
 	}
 
 	/**
-	 * Create a single channel 32-bit float {@link ImagePlus}
-	 * from a {@link RandomAccessibleInterval} using a custom {@link Converter}.
+	 * Create a single channel 32-bit float {@link ImagePlus} from a
+	 * {@link RandomAccessibleInterval} using a custom {@link Converter}.
 	 */
 	public static < T extends RealType< T > > ImagePlus wrapFloat(
 			final RandomAccessibleInterval< T > img,
@@ -253,12 +287,12 @@ public class ImageJFunctions
 		if ( n > 2 )
 		{
 			imp.setOpenAsHyperStack( true );
-			final int c = ( int )dims.dimension( 2 ), s, f;
+			final int c = ( int ) dims.dimension( 2 ), s, f;
 			if ( n > 3 )
 			{
-				s = ( int )dims.dimension( 3 );
+				s = ( int ) dims.dimension( 3 );
 				if ( n > 4 )
-					f = ( int )dims.dimension( 4 );
+					f = ( int ) dims.dimension( 4 );
 				else
 					f = 1;
 			}
@@ -273,8 +307,8 @@ public class ImageJFunctions
 	}
 
 	/**
-	 * Create a single channel 32-bit float {@link ImagePlus}
-	 * from a {@link RandomAccessibleInterval} using a custom {@link Converter}.
+	 * Create a single channel 32-bit float {@link ImagePlus} from a
+	 * {@link RandomAccessibleInterval} using a custom {@link Converter}.
 	 */
 	public static < T > ImagePlus wrapFloat(
 			final RandomAccessibleInterval< T > img,
@@ -341,7 +375,7 @@ public class ImageJFunctions
 	}
 
 	/**
-	 * Show a {@link RandomAccessibleInterval} as 24bit RGB  {@link ImagePlus}
+	 * Show a {@link RandomAccessibleInterval} as 24bit RGB {@link ImagePlus}
 	 * using a custom {@link Converter}.
 	 */
 	public static < T > ImagePlus showRGB( final RandomAccessibleInterval< T > img, final Converter< T, ARGBType > converter, final String title )
@@ -355,8 +389,8 @@ public class ImageJFunctions
 	}
 
 	/**
-	 * Create a single channel 8-bit unsigned integer {@link ImagePlus}
-	 * from a {@link RandomAccessibleInterval} using a custom {@link Converter}.
+	 * Create a single channel 8-bit unsigned integer {@link ImagePlus} from a
+	 * {@link RandomAccessibleInterval} using a custom {@link Converter}.
 	 */
 	public static < T extends RealType< T > > ImagePlus wrapUnsignedByte(
 			final RandomAccessibleInterval< T > img,
@@ -364,11 +398,11 @@ public class ImageJFunctions
 	{
 		return wrapUnsignedByte( img, new RealUnsignedByteConverter< T >( 0, 255 ), title );
 	}
-        
-        
-        /**
-	 * Create a single channel 8-bit unsigned integer {@link ImagePlus}
-	 * from a BitType {@link RandomAccessibleInterval} using a custom {@link Converter}.
+
+	/**
+	 * Create a single channel 8-bit unsigned integer {@link ImagePlus} from a
+	 * BitType {@link RandomAccessibleInterval} using a custom {@link Converter}
+	 * .
 	 */
 	public static < T extends RealType< T > > ImagePlus wrapBit(
 			final RandomAccessibleInterval< T > img,
@@ -376,11 +410,10 @@ public class ImageJFunctions
 	{
 		return wrapUnsignedByte( img, new RealUnsignedByteConverter< T >( 0, 1 ), title );
 	}
-        
 
 	/**
-	 * Create a single channel 8-bit unsigned integer {@link ImagePlus}
-	 * from a {@link RandomAccessibleInterval} using a custom {@link Converter}.
+	 * Create a single channel 8-bit unsigned integer {@link ImagePlus} from a
+	 * {@link RandomAccessibleInterval} using a custom {@link Converter}.
 	 */
 	public static < T > ImagePlus wrapUnsignedByte(
 			final RandomAccessibleInterval< T > img,
@@ -435,7 +468,7 @@ public class ImageJFunctions
 	 * {@link RandomAccessibleInterval} using a default {@link Converter} (clamp
 	 * values to range [0, 65535]).
 	 */
-	public static < T extends RealType < T > > ImagePlus wrapUnsignedShort(
+	public static < T extends RealType< T > > ImagePlus wrapUnsignedShort(
 			final RandomAccessibleInterval< T > img,
 			final String title )
 	{
@@ -443,8 +476,8 @@ public class ImageJFunctions
 	}
 
 	/**
-	 * Create a single channel 16-bit unsigned integer {@link ImagePlus}
-	 * from a {@link RandomAccessibleInterval} using a custom {@link Converter}.
+	 * Create a single channel 16-bit unsigned integer {@link ImagePlus} from a
+	 * {@link RandomAccessibleInterval} using a custom {@link Converter}.
 	 */
 	public static < T > ImagePlus wrapUnsignedShort(
 			final RandomAccessibleInterval< T > img,
@@ -456,8 +489,8 @@ public class ImageJFunctions
 	}
 
 	/**
-	 * Show a {@link RandomAccessibleInterval} as single channel 16-bit
-	 * unsigned integer {@link ImagePlus} using a custom {@link Converter}.
+	 * Show a {@link RandomAccessibleInterval} as single channel 16-bit unsigned
+	 * integer {@link ImagePlus} using a custom {@link Converter}.
 	 */
 	public static < T > ImagePlus showUnsignedShort(
 			final RandomAccessibleInterval< T > img,
@@ -496,10 +529,8 @@ public class ImageJFunctions
 	}
 
 	/*
-	public static <T extends Type<T>> ImagePlus copy( final Img<T> img, String title )
-	{
-	}
-	*/
-
+	 * public static <T extends Type<T>> ImagePlus copy( final Img<T> img,
+	 * String title ) { }
+	 */
 
 }

--- a/src/test/java/net/imglib2/img/display/imagej/ImageJFunctionDatasetTransformation.java
+++ b/src/test/java/net/imglib2/img/display/imagej/ImageJFunctionDatasetTransformation.java
@@ -1,0 +1,50 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package net.imglib2.img.display.imagej;
+
+import ij.ImagePlus;
+import net.imglib2.Cursor;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgFactory;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.type.logic.BitType;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ *
+ * @author cyril
+ */
+public class ImageJFunctionDatasetTransformation {
+    
+    
+    
+    
+    @Test
+    public void transformBitDataset() {
+        
+        
+         final ImgFactory< BitType > imgFactory = new CellImgFactory< BitType >( 5 );
+ 
+        // create an 3d-Img with dimensions 20x30x40 (here cellsize is 5x5x5)Ø
+        final Img< BitType > img1 = imgFactory.create( new long[]{ 20, 30, 40 }, new BitType() );
+        
+        Cursor<BitType> cursor = img1.cursor();
+        
+        cursor.reset();
+        // setting all the pixels as white
+        while(cursor.hasNext()) {
+            cursor.fwd();
+            cursor.get().set(new BitType(true));
+        }
+        
+        ImagePlus imp = ImageJFunctions.wrap(img1, "");
+        
+        Assert.assertEquals(ImagePlus.GRAY8,imp.getType());
+        Assert.assertEquals(255,imp.getStatistics().min,0);
+        
+    }
+}

--- a/src/test/java/net/imglib2/img/display/imagej/ImageJFunctionDatasetTransformation.java
+++ b/src/test/java/net/imglib2/img/display/imagej/ImageJFunctionDatasetTransformation.java
@@ -18,33 +18,32 @@ import org.junit.Test;
  *
  * @author cyril
  */
-public class ImageJFunctionDatasetTransformation {
-    
-    
-    
-    
-    @Test
-    public void transformBitDataset() {
-        
-        
-         final ImgFactory< BitType > imgFactory = new CellImgFactory< BitType >( 5 );
- 
-        // create an 3d-Img with dimensions 20x30x40 (here cellsize is 5x5x5)Ø
-        final Img< BitType > img1 = imgFactory.create( new long[]{ 20, 30, 40 }, new BitType() );
-        
-        Cursor<BitType> cursor = img1.cursor();
-        
-        cursor.reset();
-        // setting all the pixels as white
-        while(cursor.hasNext()) {
-            cursor.fwd();
-            cursor.get().set(new BitType(true));
-        }
-        
-        ImagePlus imp = ImageJFunctions.wrap(img1, "");
-        
-        Assert.assertEquals(ImagePlus.GRAY8,imp.getType());
-        Assert.assertEquals(255,imp.getStatistics().min,0);
-        
-    }
+public class ImageJFunctionDatasetTransformation
+{
+
+	@Test
+	public void transformBitDataset()
+	{
+
+		final ImgFactory< BitType > imgFactory = new CellImgFactory< BitType >( 5 );
+
+		// create an 3d-Img with dimensions 20x30x40 (here cellsize is 5x5x5)Ø
+		final Img< BitType > img1 = imgFactory.create( new long[] { 20, 30, 40 }, new BitType() );
+
+		Cursor< BitType > cursor = img1.cursor();
+
+		cursor.reset();
+		// setting all the pixels as white
+		while ( cursor.hasNext() )
+		{
+			cursor.fwd();
+			cursor.get().set( new BitType( true ) );
+		}
+
+		ImagePlus imp = ImageJFunctions.wrap( img1, "" );
+
+		Assert.assertEquals( ImagePlus.GRAY8, imp.getType() );
+		Assert.assertEquals( 255, imp.getStatistics().min, 0 );
+
+	}
 }


### PR DESCRIPTION
For some reason, Bit images where transformed into 16-bit images. I changed the ImageJFunction.wrap method so it transforms BitTypes into 8-Bit ImagePlus (common binary type
of IJ1). BitTypes of value "True" are mapped to the byte value 255.