### PR TITLE
multithreaded show methods

### DIFF
--- a/src/main/java/net/imglib2/display/projector/MultithreadedIterableIntervalProjector2D.java
+++ b/src/main/java/net/imglib2/display/projector/MultithreadedIterableIntervalProjector2D.java
@@ -1,0 +1,189 @@
+package net.imglib2.display.projector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import net.imglib2.Cursor;
+import net.imglib2.FinalInterval;
+import net.imglib2.FlatIterationOrder;
+import net.imglib2.IterableInterval;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.converter.Converter;
+import net.imglib2.view.RandomAccessibleIntervalCursor;
+import net.imglib2.view.Views;
+
+/**
+ * Multithreaded version of {@link IterableIntervalProjector2D} by 
+ * 
+ * @author Michael Zinsmaier
+ * @author Martin Horn
+ * @author Christian Dietz
+ * 
+ * The output
+ * {@link IterableInterval} will be divided into approximately equally sized
+ * portions that are filled by separate threads.
+ *
+ * @author David Hoerl
+ *
+ * @param <A>
+ *            pixel type of the input
+ * @param <B>
+ *            pixel type of the output
+ */
+public class MultithreadedIterableIntervalProjector2D<A, B> extends IterableIntervalProjector2D< A, B >
+{
+
+	final ExecutorService service;
+
+	private final int dimX;
+
+	private final int dimY;
+
+	private final int nTasks;
+
+	public MultithreadedIterableIntervalProjector2D(int dimX, int dimY, RandomAccessible< A > source,
+			IterableInterval< B > target, Converter< ? super A, B > converter, ExecutorService service, int nTasks)
+	{
+		super( dimX, dimY, source, target, converter );
+
+		this.service = service;
+		this.dimX = dimX;
+		this.dimY = dimY;
+		this.nTasks = nTasks;
+	}
+
+	public MultithreadedIterableIntervalProjector2D(int dimX, int dimY, RandomAccessible< A > source,
+			IterableInterval< B > target, Converter< ? super A, B > converter, ExecutorService service)
+	{
+		this( dimX, dimY, source, target, converter, service, Runtime.getRuntime().availableProcessors() );
+	}
+
+	@Override
+	public void map()
+	{
+		// fix interval for all dimensions
+		for ( int d = 0; d < position.length; ++d )
+			min[d] = max[d] = position[d];
+
+		min[dimX] = target.min( 0 );
+		min[dimY] = target.min( 1 );
+		max[dimX] = target.max( 0 );
+		max[dimY] = target.max( 1 );
+
+		final IterableInterval< A > ii = Views.iterable( Views.interval( source, new FinalInterval( min, max ) ) );
+
+		final long portionSize = target.size() / nTasks;
+
+		final List< Callable< Void > > tasks = new ArrayList<>();
+		final AtomicInteger ai = new AtomicInteger();
+
+		for ( int t = 0; t < nTasks; ++t )
+		{
+			tasks.add( new Callable< Void >()
+			{
+
+				@Override
+				public Void call() throws Exception
+				{
+					int i = ai.getAndIncrement();
+
+					final Cursor< B > targetCursor = target.localizingCursor();
+
+					// we might need either a cursor or a RandomAccess
+					final RandomAccess< A > sourceRandomAccess = source.randomAccess();
+					sourceRandomAccess.setPosition( position );
+
+					final Cursor< A > sourceCursor = ii.cursor();
+
+					// jump to correct starting point
+					targetCursor.jumpFwd( i * portionSize );
+					sourceCursor.jumpFwd( i * portionSize );
+					long stepsTaken = 0;
+
+					if ( target.iterationOrder().equals( ii.iterationOrder() )
+							&& !( sourceCursor instanceof RandomAccessibleIntervalCursor ) )
+					{
+						// either map a portion or (for the last portion) go
+						// until the end
+						while ( ( i != nTasks - 1 && stepsTaken < portionSize )
+								|| ( i == nTasks - 1 && targetCursor.hasNext() ) )
+						{
+							stepsTaken++;
+							converter.convert( sourceCursor.next(), targetCursor.next() );
+						}
+					}
+
+					else if ( target.iterationOrder() instanceof FlatIterationOrder )
+					{
+
+						final long cr = -target.dimension( 0 );
+						final long width = target.dimension( 0 );
+						final long height = target.dimension( 1 );
+
+						final long initX = ( i * portionSize ) % width;
+						final long initY = ( i * portionSize ) / width;
+						// either map a portion or (for the last portion) go
+						// until the end
+						final long endX = ( i == nTasks - 1 ) ? width : ( initX + ( i + 1 ) * portionSize ) % width;
+						final long endY = ( i == nTasks - 1 ) ? height - 1
+								: ( initX + ( i + 1 ) * portionSize ) / width;
+
+						sourceRandomAccess.setPosition( initX, dimX );
+						sourceRandomAccess.setPosition( initY, dimY );
+
+						for ( long y = initY; y <= endY; ++y )
+						{
+							for ( long x = ( y == initY ? initX : 0 ); x < ( y == endY ? endX : width ); ++x )
+							{
+								targetCursor.fwd();
+								converter.convert( sourceRandomAccess.get(), targetCursor.get() );
+								sourceRandomAccess.fwd( dimX );
+
+							}
+							sourceRandomAccess.move( cr, dimX );
+							sourceRandomAccess.fwd( dimY );
+						}
+					}
+
+					else
+					{
+						// either map a portion or (for the last portion) go
+						// until the end
+						while ( ( i != nTasks - 1 && stepsTaken < portionSize )
+								|| ( i == nTasks - 1 && targetCursor.hasNext() ) )
+						{
+							stepsTaken++;
+
+							final B b = targetCursor.next();
+							sourceRandomAccess.setPosition( targetCursor.getLongPosition( 0 ), dimX );
+							sourceRandomAccess.setPosition( targetCursor.getLongPosition( 1 ), dimY );
+
+							converter.convert( sourceRandomAccess.get(), b );
+						}
+					}
+
+					return null;
+				}
+			} );
+		}
+
+		try
+		{
+			List< Future< Void > > futures = service.invokeAll( tasks );
+			for ( Future< Void > f : futures )
+				f.get();
+		}
+		catch ( InterruptedException | ExecutionException e )
+		{
+			e.printStackTrace();
+		}
+
+	}
+
+}

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackARGB.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackARGB.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.img.display.imagej;
 
+import java.util.concurrent.ExecutorService;
+
 import ij.ImagePlus;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converter;
@@ -45,9 +47,13 @@ import net.imglib2.type.numeric.ARGBType;
  */
 public class ImageJVirtualStackARGB< S > extends ImageJVirtualStack< S, ARGBType >
 {
-	public ImageJVirtualStackARGB( RandomAccessibleInterval< S > source, Converter< S, ARGBType > converter )
+	public ImageJVirtualStackARGB( RandomAccessibleInterval< S > source, Converter< S, ARGBType > converter)
 	{
-		super( source, converter, new ARGBType(), ImagePlus.COLOR_RGB );
+		this(source, converter, null);
+	}
+	public ImageJVirtualStackARGB( RandomAccessibleInterval< S > source, Converter< S, ARGBType > converter, ExecutorService service )
+	{
+		super( source, converter, new ARGBType(), ImagePlus.COLOR_RGB, service);
 		imageProcessor.setMinAndMax( 0, 255 );
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.img.display.imagej;
 
+import java.util.concurrent.ExecutorService;
+
 import ij.ImagePlus;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converter;
@@ -45,9 +47,13 @@ import net.imglib2.type.numeric.integer.UnsignedByteType;
  */
 public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< S, UnsignedByteType >
 {
-	public ImageJVirtualStackUnsignedByte( RandomAccessibleInterval< S > source, Converter< S, UnsignedByteType > converter )
+	public ImageJVirtualStackUnsignedByte( RandomAccessibleInterval< S > source, Converter< S, UnsignedByteType > converter)
 	{
-		super( source, converter, new UnsignedByteType(), ImagePlus.GRAY8 );
+		this( source, converter, null );
+	}
+	public ImageJVirtualStackUnsignedByte( RandomAccessibleInterval< S > source, Converter< S, UnsignedByteType > converter, ExecutorService service )
+	{
+		super( source, converter, new UnsignedByteType(), ImagePlus.GRAY8 , service);
 		imageProcessor.setMinAndMax( 0, 255 );
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedShort.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedShort.java
@@ -34,6 +34,8 @@
 
 package net.imglib2.img.display.imagej;
 
+import java.util.concurrent.ExecutorService;
+
 import ij.ImagePlus;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converter;
@@ -48,9 +50,14 @@ import net.imglib2.util.Util;
  */
 public class ImageJVirtualStackUnsignedShort< S > extends ImageJVirtualStack< S, UnsignedShortType >
 {
-	public ImageJVirtualStackUnsignedShort( RandomAccessibleInterval< S > source, Converter< S, UnsignedShortType > converter )
+	public ImageJVirtualStackUnsignedShort( RandomAccessibleInterval< S > source, Converter< S, UnsignedShortType > converter)
 	{
-		super( source, converter, new UnsignedShortType(), ImagePlus.GRAY16 );
+		this( source, converter, null );
+	}
+
+	public ImageJVirtualStackUnsignedShort( RandomAccessibleInterval< S > source, Converter< S, UnsignedShortType > converter, ExecutorService service )
+	{
+		super( source, converter, new UnsignedShortType(), ImagePlus.GRAY16, service );
 
 		int maxDisplay = (1 << 16) - 1;
 		


### PR DESCRIPTION
In our [BigStitcher](https://github.com/PreibischLab/BigStitcher) and corresponding newer versions of SPIM_Registration, @StephanPreibisch and I create large virtual RAIs, that we wish to display as plain-old  `ImagePlus`s. Since the virtual fusion of every plane can be quite computationally intensive, doing it multi-threaded provides a great speed improvement (and a more responsive user experience).

To achieve this, we wrote `MultithreadedIterableIntervalProjector2D`, a multi-threaded version of `IterableIntervalProjector2D`.
We overload the constructors of `ImageJVirtualStack` and subclasses to take an additional `ExecutorService`. This may be null, in which case the "old" `IterableIntervalProjector2D` is used. The old constructors default to single-threaded behaviour.
The same goes for the RAI -> ImagePlus methods in `ImageJFunctions`: we provide versions that take an `ExecutorService` and use it to perform multi-threaded plane filling. The old signatures provide unchanged, single-threaded beahviour.