### PR TITLE
Fast wrappers for ImagePlus-Img-conversions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,10 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 			<artifactId>imglib2</artifactId>
 			<version>5.0.0</version>
 		</dependency>
+		<dependency>
+			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2-cache</artifactId>
+		</dependency>
 
 		<!-- ImageJ dependencies -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -166,5 +166,17 @@ Jean-Yves Tinevez and Michael Zinsmaier.</license.copyrightOwners>
 			<classifier>tests</classifier>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<version>1.19</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<version>1.19</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/src/main/java/net/imglib2/img/VirtualStackAdapter.java
+++ b/src/main/java/net/imglib2/img/VirtualStackAdapter.java
@@ -1,0 +1,186 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img;
+
+import ij.ImagePlus;
+import ij.measure.Calibration;
+import net.imagej.ImgPlus;
+import net.imagej.axis.Axes;
+import net.imagej.axis.CalibratedAxis;
+import net.imagej.axis.DefaultLinearAxis;
+import net.imglib2.cache.Cache;
+import net.imglib2.cache.ref.SoftRefLoaderRemoverCache;
+import net.imglib2.exception.IncompatibleTypeException;
+import net.imglib2.img.basictypeaccess.ByteAccess;
+import net.imglib2.img.basictypeaccess.CharAccess;
+import net.imglib2.img.basictypeaccess.DoubleAccess;
+import net.imglib2.img.basictypeaccess.FloatAccess;
+import net.imglib2.img.basictypeaccess.IntAccess;
+import net.imglib2.img.basictypeaccess.LongAccess;
+import net.imglib2.img.basictypeaccess.ShortAccess;
+import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.img.basictypeaccess.array.ShortArray;
+import net.imglib2.img.planar.PlanarImg;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.NativeTypeFactory;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Fraction;
+
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Function;
+import java.util.stream.LongStream;
+
+/**
+ * Wrapper for ImagePlus using imglib2-caches.
+ * It loads the planes lazily, which is especially useful when wrapping a virtual stack.
+ *
+ * @author Matthias Arzt
+ */
+
+public class VirtualStackAdapter
+{
+
+	public static ImgPlus< UnsignedByteType > wrapByte( ImagePlus image )
+	{
+		return internWrap( image, ImagePlus.GRAY8, new UnsignedByteType(), array -> new ByteArray( ( byte[] ) array ) );
+	}
+
+	public static ImgPlus< UnsignedShortType > wrapShort( ImagePlus image )
+	{
+		return internWrap( image, ImagePlus.GRAY16, new UnsignedShortType(), array -> new ShortArray( ( short[] ) array ) );
+	}
+
+	public static ImgPlus< FloatType > wrapFloat( ImagePlus image )
+	{
+		return internWrap( image, ImagePlus.GRAY32, new FloatType(), array -> new FloatArray( ( float[] ) array ) );
+	}
+
+	public static ImgPlus< ARGBType > wrapRGBA( ImagePlus image )
+	{
+		return internWrap( image, ImagePlus.COLOR_RGB, new ARGBType(), array -> new IntArray( ( int[] ) array ) );
+	}
+
+	public static ImgPlus< ? > wrap( ImagePlus image )
+	{
+		switch ( image.getType() )
+		{
+		case ImagePlus.GRAY8:
+			return wrapByte( image );
+		case ImagePlus.GRAY16:
+			return wrapShort( image );
+		case ImagePlus.GRAY32:
+			return wrapFloat( image );
+		case ImagePlus.COLOR_RGB:
+			return wrapRGBA( image );
+		}
+		throw new RuntimeException( "Only 8, 16, 32-bit and RGB supported!" );
+	}
+
+	private static < T extends NativeType< T >, A extends ArrayDataAccess< A > > ImgPlus< T > internWrap( ImagePlus image, int expectedType, T type, Function< Object, A > createArrayAccess )
+	{
+		if ( image.getType() != expectedType )
+			throw new IllegalArgumentException();
+		ImagePlusLoader< A > loader = new ImagePlusLoader<>( image, createArrayAccess );
+		final long[] dimensions = getNonTrivialDimensions(image);
+		PlanarImg< T, A > cached = new PlanarImg<T, A>( loader, dimensions, new Fraction() );
+		cached.setLinkedType( (( NativeTypeFactory< T, A > ) type.getNativeTypeFactory()).createLinkedType( cached ) );
+		CalibratedAxis[] axes = getNonTrivialAxes( image );
+		ImgPlus< T > wrap = new ImgPlus<>(cached, image.getTitle(), axes);
+		return wrap;
+	}
+
+	private static long[] getNonTrivialDimensions(ImagePlus image) {
+		LongStream xy = LongStream.of(image.getWidth(), image.getHeight());
+		LongStream czt = LongStream.of(image.getNChannels(), image.getNSlices(), image.getNFrames());
+		return LongStream.concat(xy, czt.filter(x -> x > 1)).toArray();
+	}
+
+	private static CalibratedAxis[] getNonTrivialAxes( ImagePlus image ) {
+		List<CalibratedAxis> result = new ArrayList<>();
+		Calibration calibration = image.getCalibration();
+		result.add(new DefaultLinearAxis(Axes.X, calibration.getXUnit(), calibration.pixelWidth, calibration.xOrigin));
+		result.add(new DefaultLinearAxis(Axes.Y, calibration.getYUnit(), calibration.pixelHeight, calibration.yOrigin));
+		if(image.getNChannels() > 1)
+			result.add(new DefaultLinearAxis(Axes.CHANNEL));
+		if(image.getNSlices() > 1)
+			result.add(new DefaultLinearAxis(Axes.Z, calibration.getZUnit(), calibration.pixelDepth, calibration.zOrigin));
+		if(image.getNFrames() > 1)
+			result.add(new DefaultLinearAxis(Axes.TIME, calibration.getTimeUnit(), calibration.frameInterval));
+		return result.toArray(new CalibratedAxis[0]);
+	}
+
+	private static class ImagePlusLoader< A extends ArrayDataAccess< A > > extends AbstractList< A >
+	{
+		private final ImagePlus image;
+
+		private final Cache<Integer, A> cache;
+
+		private final Function< Object, A > arrayFactory;
+
+		public ImagePlusLoader( final ImagePlus image, Function< Object, A > arrayFactory )
+		{
+			this.arrayFactory = arrayFactory;
+			this.image = image;
+			cache = new SoftRefLoaderRemoverCache<Integer, A>().withLoader(this::load).withRemover((key, value) -> {});
+		}
+
+		@Override
+		public A get(int key) {
+			try {
+				return cache.get(key);
+			} catch (ExecutionException e) {
+				throw new RuntimeException(e);
+			}
+		}
+
+		private A load(Integer key) {
+			return arrayFactory.apply( image.getStack().getPixels(key + 1) );
+		}
+
+		@Override
+		public int size() {
+			return image.getStackSize();
+		}
+	}
+}

--- a/src/main/java/net/imglib2/img/VirtualStackAdapter.java
+++ b/src/main/java/net/imglib2/img/VirtualStackAdapter.java
@@ -39,14 +39,6 @@ import net.imagej.ImgPlus;
 import net.imagej.axis.CalibratedAxis;
 import net.imglib2.cache.Cache;
 import net.imglib2.cache.ref.SoftRefLoaderRemoverCache;
-import net.imglib2.exception.IncompatibleTypeException;
-import net.imglib2.img.basictypeaccess.ByteAccess;
-import net.imglib2.img.basictypeaccess.CharAccess;
-import net.imglib2.img.basictypeaccess.DoubleAccess;
-import net.imglib2.img.basictypeaccess.FloatAccess;
-import net.imglib2.img.basictypeaccess.IntAccess;
-import net.imglib2.img.basictypeaccess.LongAccess;
-import net.imglib2.img.basictypeaccess.ShortAccess;
 import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
 import net.imglib2.img.basictypeaccess.array.ByteArray;
 import net.imglib2.img.basictypeaccess.array.FloatArray;
@@ -77,26 +69,52 @@ import java.util.stream.LongStream;
 public class VirtualStackAdapter
 {
 
+	/**
+	 * Wraps a 8 bit {@link ImagePlus}, into an {@link ImgPlus}, that is backed by a {@link PlanarImg}.
+	 * The {@link PlanarImg} loads the planes only if needed, and caches them.
+	 * The axes of the returned image are set according to the calibration of the given image.
+	 */
 	public static ImgPlus< UnsignedByteType > wrapByte( ImagePlus image )
 	{
 		return internWrap( image, ImagePlus.GRAY8, new UnsignedByteType(), array -> new ByteArray( ( byte[] ) array ) );
 	}
 
+	/**
+	 * Wraps a 16 bit {@link ImagePlus}, into an {@link ImgPlus}, that is backed by a {@link PlanarImg}.
+	 * The {@link PlanarImg} loads the planes only if needed, and caches them.
+	 * The axes of the returned image are set according to the calibration of the given image.
+	 */
 	public static ImgPlus< UnsignedShortType > wrapShort( ImagePlus image )
 	{
 		return internWrap( image, ImagePlus.GRAY16, new UnsignedShortType(), array -> new ShortArray( ( short[] ) array ) );
 	}
 
+	/**
+	 * Wraps a 32 bit {@link ImagePlus}, into an {@link ImgPlus}, that is backed by a {@link PlanarImg}.
+	 * The {@link PlanarImg} loads the planes only if needed, and caches them.
+	 * The axes of the returned image are set according to the calibration of the given image.
+	 */
 	public static ImgPlus< FloatType > wrapFloat( ImagePlus image )
 	{
 		return internWrap( image, ImagePlus.GRAY32, new FloatType(), array -> new FloatArray( ( float[] ) array ) );
 	}
 
+	/**
+	 * Wraps a 24 bit {@link ImagePlus}, into an {@link ImgPlus}, that is backed by a {@link PlanarImg}.
+	 * The {@link PlanarImg} loads the planes only if needed, and caches them.
+	 * The axes of the returned image are set according to the calibration of the given image.
+	 */
 	public static ImgPlus< ARGBType > wrapRGBA( ImagePlus image )
 	{
 		return internWrap( image, ImagePlus.COLOR_RGB, new ARGBType(), array -> new IntArray( ( int[] ) array ) );
 	}
 
+	/**
+	 * Wraps an {@link ImagePlus}, into an {@link ImgPlus}, that is backed by a {@link PlanarImg}.
+	 * The {@link PlanarImg} loads the planes only if needed, and caches them.
+	 * The pixel type of the returned image depends on the type of the ImagePlus.
+	 * The axes of the returned image are set according to the calibration of the given image.
+	 */
 	public static ImgPlus< ? > wrap( ImagePlus image )
 	{
 		switch ( image.getType() )

--- a/src/main/java/net/imglib2/img/display/imagej/AbstractVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/AbstractVirtualStack.java
@@ -55,6 +55,7 @@ public abstract class AbstractVirtualStack extends VirtualStack
 	private ColorModel colorModel;
 
 	private Rectangle roi;
+	private double min = 0.0, max = 1.0;
 
 	public AbstractVirtualStack( int width, int height, int size, int bitDepth )
 	{
@@ -65,6 +66,23 @@ public abstract class AbstractVirtualStack extends VirtualStack
 		this.bitDepth = bitDepth;
 		this.colorModel = null;
 		this.roi = new Rectangle( 0, 0, width, height );
+	}
+
+	protected void setMinAndMax( double min, double max ) {
+		this.min = min;
+		this.max = max;
+	}
+
+	@Override public abstract Object getPixels( int n );
+
+	@Override
+	public ImageProcessor getProcessor(final int n)
+	{
+
+		Object pixels = getPixels( n );
+		ImageProcessor processor = ImageProcessorUtils.initProcessor( width, height, pixels, colorModel );
+		processor.setMinAndMax( min, max );
+		return processor;
 	}
 
 	@Override public void addSlice( String name )
@@ -97,14 +115,10 @@ public abstract class AbstractVirtualStack extends VirtualStack
 		// ignore
 	}
 
-	@Override public abstract Object getPixels( int n );
-
 	@Override public void setPixels( Object pixels, int n )
 	{
 		// ignore for now
 	}
-
-	@Override public abstract ImageProcessor getProcessor( int n );
 
 	/**
 	 * Currently not implemented
@@ -294,5 +308,4 @@ public abstract class AbstractVirtualStack extends VirtualStack
 	{
 		throw new UnsupportedOperationException();
 	}
-
 }

--- a/src/main/java/net/imglib2/img/display/imagej/AbstractVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/AbstractVirtualStack.java
@@ -1,0 +1,298 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.display.imagej;
+
+import ij.ImageStack;
+import ij.VirtualStack;
+import ij.process.ImageProcessor;
+
+import java.awt.*;
+import java.awt.image.ColorModel;
+import java.util.stream.IntStream;
+
+public abstract class AbstractVirtualStack extends VirtualStack
+{
+	private final int width;
+
+	private final int height;
+
+	private final int size;
+
+	private final int bitDepth;
+
+	private ColorModel colorModel;
+
+	private Rectangle roi;
+
+	public AbstractVirtualStack( int width, int height, int size, int bitDepth )
+	{
+		super( 10, 10, null, "" );
+		this.width = width;
+		this.height = height;
+		this.size = size;
+		this.bitDepth = bitDepth;
+		this.colorModel = null;
+		this.roi = new Rectangle( 0, 0, width, height );
+	}
+
+	@Override public void addSlice( String name )
+	{
+		// ignore
+	}
+
+	@Override public void addSlice( String sliceLabel, Object pixels )
+	{
+		// ignore
+	}
+
+	@Override public void addSlice( String sliceLabel, ImageProcessor ip )
+	{
+		// ignore
+	}
+
+	@Override public void addSlice( String sliceLabel, ImageProcessor ip, int n )
+	{
+		// ignore
+	}
+
+	@Override public void deleteSlice( int n )
+	{
+		// ignore
+	}
+
+	@Override public void deleteLastSlice()
+	{
+		// ignore
+	}
+
+	@Override public abstract Object getPixels( int n );
+
+	@Override public void setPixels( Object pixels, int n )
+	{
+		// ignore for now
+	}
+
+	@Override public abstract ImageProcessor getProcessor( int n );
+
+	/**
+	 * Currently not implemented
+	 */
+	@Override public int saveChanges( int n )
+	{
+		return -1;
+	}
+
+	@Override public int getSize()
+	{
+		return size;
+	}
+
+	@Override public String getSliceLabel( int n )
+	{
+		return Integer.toString( n );
+	}
+
+	@Override public Object[] getImageArray()
+	{
+		return null; // this is the same as VirtualStack
+	}
+
+	@Override public void setSliceLabel( String label, int n )
+	{
+		// slice labels are not supported -> do nothing
+	}
+
+	@Override public boolean isVirtual()
+	{
+		return true;
+	}
+
+	@Override public void trim()
+	{
+		// ignore
+	}
+
+	@Override public String getDirectory()
+	{
+		return ""; // there is no directory that can be returned
+	}
+
+	@Override public String getFileName( int n )
+	{
+		return ""; // there is no filename, but I don't want to return null
+	}
+
+	@Override public void setBitDepth( int bitDepth )
+	{
+		// ignore
+	}
+
+	@Override public int getBitDepth()
+	{
+		return bitDepth;
+	}
+
+	@Override public ImageStack sortDicom( String[] strings, String[] info, int maxDigits )
+	{
+		// ignore
+		return this;
+	}
+
+	@Override public void addUnsignedShortSlice( String sliceLabel, Object pixels )
+	{
+		super.addUnsignedShortSlice( sliceLabel, pixels );
+	}
+
+	@Override public void addSlice( ImageProcessor ip )
+	{
+		// ignore
+	}
+
+	@Override public int getWidth()
+	{
+		return width;
+	}
+
+	@Override public int getHeight()
+	{
+		return height;
+	}
+
+	@Override public void setRoi( Rectangle roi )
+	{
+		this.roi = roi;
+	}
+
+	@Override public Rectangle getRoi()
+	{
+		return roi;
+	}
+
+	@Override public void update( ImageProcessor ip )
+	{
+		colorModel = ip.getColorModel();
+	}
+
+	@Override public int size()
+	{
+		return size;
+	}
+
+	@Override public String[] getSliceLabels()
+	{
+		return IntStream.range( 0, size ).mapToObj( this::getSliceLabel ).toArray( String[]::new );
+	}
+
+	@Override public String getShortSliceLabel( int n )
+	{
+		return getSliceLabel( n );
+	}
+
+	@Override public void setProcessor( ImageProcessor ip, int n )
+	{
+		// ignore
+	}
+
+	@Override public void setColorModel( ColorModel cm )
+	{
+		this.colorModel = cm;
+	}
+
+	@Override public ColorModel getColorModel()
+	{
+		return colorModel;
+	}
+
+	@Override public boolean isRGB()
+	{
+		return false;
+	}
+
+	@Override public boolean isHSB()
+	{
+		return false;
+	}
+
+	@Override public boolean isLab()
+	{
+		return false;
+	}
+
+	@Override public String toString()
+	{
+		return super.toString();
+	}
+
+	@Override public float[] getVoxels( int x0, int y0, int z0, int w, int h, int d, float[] voxels )
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override public float[] getVoxels( int x0, int y0, int z0, int w, int h, int d, float[] voxels, int channel )
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override public void setVoxels( int x0, int y0, int z0, int w, int h, int d, float[] voxels )
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override public void setVoxels( int x0, int y0, int z0, int w, int h, int d, float[] voxels, int channel )
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override public void drawSphere( double radius, int xc, int yc, int zc )
+	{
+		super.drawSphere( radius, xc, yc, zc );
+	}
+
+	@Override public ImageStack duplicate()
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override public ImageStack crop( int x, int y, int z, int width, int height, int depth )
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override public ImageStack convertToFloat()
+	{
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/src/main/java/net/imglib2/img/display/imagej/ArrayImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ArrayImgToVirtualStack.java
@@ -1,0 +1,90 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.display.imagej;
+
+import ij.ImagePlus;
+import ij.process.ImageProcessor;
+import net.imagej.ImgPlus;
+import net.imagej.axis.Axes;
+import net.imagej.axis.AxisType;
+import net.imagej.axis.CalibratedAxis;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
+import net.imglib2.type.NativeType;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ArrayImgToVirtualStack
+{
+	private ArrayImgToVirtualStack()
+	{
+		// prevent from instantiation
+	}
+
+	public static boolean isSupported( ImgPlus< ? > imgPlus )
+	{
+		return imgPlus.getImg() instanceof ArrayImg &&
+				imgPlus.numDimensions() == 2 &&
+				checkAxis( getAxes( imgPlus ) ) &&
+				ImageProcessorUtils.isSupported( ( NativeType< ? > ) imgPlus.randomAccess().get() );
+	}
+
+	public static ImagePlus wrap( ImgPlus< ? > imgPlus )
+	{
+		Img< ? > img = imgPlus.getImg();
+		if ( !( img instanceof ArrayImg ) )
+			throw new IllegalArgumentException( "Expecting ArrayImg" );
+		ArrayImg< ?, ArrayDataAccess< ? > > arrayImg = ( ArrayImg< ?, ArrayDataAccess< ? > > ) img;
+		int sizeX = ( int ) img.dimension( 0 );
+		int sizeY = ( int ) img.dimension( 1 );
+		Object pixels = arrayImg.update( null ).getCurrentStorageArray();
+		ImageProcessor processor = ImageProcessorUtils.initProcessor( sizeX, sizeY, pixels, null );
+		return new ImagePlus( imgPlus.getName(), processor );
+	}
+
+	private static boolean checkAxis( List< AxisType > axes )
+	{
+		return axes.size() == 2 && axes.get( 0 ) == Axes.X && axes.get( 1 ) == Axes.Y;
+	}
+
+	private static List< AxisType > getAxes( ImgPlus< ? > img )
+	{
+		return IntStream.range( 0, img.numDimensions() ).mapToObj( img::axis ).map( CalibratedAxis::type ).collect( Collectors.toList() );
+	}
+
+}

--- a/src/main/java/net/imglib2/img/display/imagej/ArrayImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ArrayImgToVirtualStack.java
@@ -58,6 +58,7 @@ public class ArrayImgToVirtualStack
 
 	public static boolean isSupported( ImgPlus< ? > imgPlus )
 	{
+		imgPlus = ImgPlusViews.fixAxes( imgPlus );
 		return imgPlus.getImg() instanceof ArrayImg &&
 				imgPlus.numDimensions() == 2 &&
 				checkAxis( getAxes( imgPlus ) ) &&
@@ -66,6 +67,7 @@ public class ArrayImgToVirtualStack
 
 	public static ImagePlus wrap( ImgPlus< ? > imgPlus )
 	{
+		imgPlus = ImgPlusViews.fixAxes( imgPlus );
 		Img< ? > img = imgPlus.getImg();
 		if ( !( img instanceof ArrayImg ) )
 			throw new IllegalArgumentException( "Expecting ArrayImg" );

--- a/src/main/java/net/imglib2/img/display/imagej/ArrayImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ArrayImgToVirtualStack.java
@@ -74,7 +74,9 @@ public class ArrayImgToVirtualStack
 		int sizeY = ( int ) img.dimension( 1 );
 		Object pixels = arrayImg.update( null ).getCurrentStorageArray();
 		ImageProcessor processor = ImageProcessorUtils.initProcessor( sizeX, sizeY, pixels, null );
-		return new ImagePlus( imgPlus.getName(), processor );
+		ImagePlus imagePlus = new ImagePlus(imgPlus.getName(), processor);
+		CalibrationUtils.copyCalibrationToImagePlus( imgPlus, imagePlus );
+		return imagePlus;
 	}
 
 	private static boolean checkAxis( List< AxisType > axes )

--- a/src/main/java/net/imglib2/img/display/imagej/ArrayImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ArrayImgToVirtualStack.java
@@ -44,6 +44,10 @@ import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
 import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.FloatType;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -56,6 +60,12 @@ public class ArrayImgToVirtualStack
 		// prevent from instantiation
 	}
 
+	/**
+	 * Indicates if {@link #wrap(ImgPlus)} wrap} supports the image.
+	 *
+	 * @see PlanarImgToVirtualStack
+	 * @see ImgToVirtualStack
+	 */
 	public static boolean isSupported( ImgPlus< ? > imgPlus )
 	{
 		imgPlus = ImgPlusViews.fixAxes( imgPlus );
@@ -65,6 +75,20 @@ public class ArrayImgToVirtualStack
 				ImageProcessorUtils.isSupported( ( NativeType< ? > ) imgPlus.randomAccess().get() );
 	}
 
+	/**
+	 * Takes an {@link ImgPlus} (IJ2) and wraps it into an {@link ImagePlus} (IJ1).
+	 * This only works when {@link ImgPlus} is backed by a two dimensional {@link ArrayImg}.
+	 * Type of the image must be {@link UnsignedByteType}, {@link UnsignedShortType}, {@link ARGBType} or {@link FloatType}.
+	 * <p>
+	 * The returned {@link ImagePlus} uses the same pixel buffer as the given image.
+	 * Changes to the {@link ImagePlus} are therefore correctly reflected in the {@link ImgPlus}.
+	 * The title and calibration are derived from the given image.
+	 * <p>
+	 * Use {@link #isSupported(ImgPlus)} to check if an {@link ImagePlus} is supported.
+	 *
+	 * @see PlanarImgToVirtualStack
+	 * @see ImgToVirtualStack
+	 */
 	public static ImagePlus wrap( ImgPlus< ? > imgPlus )
 	{
 		imgPlus = ImgPlusViews.fixAxes( imgPlus );

--- a/src/main/java/net/imglib2/img/display/imagej/CalibrationUtils.java
+++ b/src/main/java/net/imglib2/img/display/imagej/CalibrationUtils.java
@@ -1,0 +1,96 @@
+/*-
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.display.imagej;
+
+import ij.ImagePlus;
+import ij.measure.Calibration;
+import net.imagej.ImgPlus;
+import net.imagej.axis.Axes;
+import net.imagej.axis.CalibratedAxis;
+import net.imagej.axis.DefaultLinearAxis;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CalibrationUtils {
+
+	/**
+	 * Sets the {@link Calibration} data on the provided {@link ImagePlus}.
+	 */
+	public static void copyCalibrationToImagePlus(final ImgPlus<?> imgPlus, final ImagePlus imp)
+	{
+		final Calibration calibration = imp.getCalibration();
+		final int xIndex = imgPlus.dimensionIndex(Axes.X);
+		final int yIndex = imgPlus.dimensionIndex(Axes.Y);
+		final int zIndex = imgPlus.dimensionIndex(Axes.Z);
+		final int tIndex = imgPlus.dimensionIndex(Axes.TIME);
+
+		if (xIndex >= 0) {
+			calibration.pixelWidth = imgPlus.averageScale( xIndex );
+			CalibratedAxis axis = imgPlus.axis( xIndex );
+			calibration.xOrigin = axis.calibratedValue( 0 );
+			calibration.setXUnit( axis.unit());
+		}
+		if (yIndex >= 0) {
+			calibration.pixelHeight = imgPlus.averageScale( yIndex );
+			CalibratedAxis axis = imgPlus.axis( yIndex );
+			calibration.yOrigin = axis.calibratedValue( 0 );
+			calibration.setYUnit( axis.unit());
+		}
+		if (zIndex >= 0) {
+			calibration.pixelDepth = imgPlus.averageScale( zIndex );
+			CalibratedAxis axis = imgPlus.axis( zIndex );
+			calibration.zOrigin = axis.calibratedValue( 0 );
+			calibration.setZUnit( axis.unit());
+		}
+		if (tIndex >= 0) {
+			calibration.frameInterval = imgPlus.averageScale( tIndex );
+			calibration.setTimeUnit(imgPlus.axis(tIndex).unit());
+		}
+	}
+
+	public static CalibratedAxis[] getNonTrivialAxes( ImagePlus image ) {
+		List<CalibratedAxis> result = new ArrayList<>();
+		Calibration calibration = image.getCalibration();
+		result.add(new DefaultLinearAxis(Axes.X, calibration.getXUnit(), calibration.pixelWidth, calibration.xOrigin));
+		result.add(new DefaultLinearAxis(Axes.Y, calibration.getYUnit(), calibration.pixelHeight, calibration.yOrigin));
+		if(image.getNChannels() > 1)
+			result.add(new DefaultLinearAxis(Axes.CHANNEL));
+		if(image.getNSlices() > 1)
+			result.add(new DefaultLinearAxis(Axes.Z, calibration.getZUnit(), calibration.pixelDepth, calibration.zOrigin));
+		if(image.getNFrames() > 1)
+			result.add(new DefaultLinearAxis(Axes.TIME, calibration.getTimeUnit(), calibration.frameInterval));
+		return result.toArray(new CalibratedAxis[0]);
+	}
+}

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJFunctions.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJFunctions.java
@@ -36,14 +36,11 @@ package net.imglib2.img.display.imagej;
 
 import ij.ImagePlus;
 import ij.VirtualStack;
-import ij.measure.Calibration;
 
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import net.imagej.ImgPlus;
-import net.imagej.axis.Axes;
 import net.imglib2.Dimensions;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.ComplexPowerGLogFloatConverter;
@@ -246,36 +243,7 @@ public class ImageJFunctions
 		{
 
 			final ImgPlus< T > imgplus = ( ImgPlus< T > ) img;
-			final Calibration impcal = target.getCalibration();
-
-			// TODO - using averageScale() introduces error for nonlinear axes
-
-			final int xaxis = imgplus.dimensionIndex( Axes.X );
-			if ( xaxis >= 0 )
-			{
-				impcal.pixelWidth = imgplus.averageScale( xaxis );
-				impcal.xOrigin = imgplus.axis( xaxis ).calibratedValue( 0 );
-			}
-
-			final int yaxis = imgplus.dimensionIndex( Axes.Y );
-			if ( yaxis >= 0 )
-			{
-				impcal.pixelHeight = imgplus.averageScale( yaxis );
-				impcal.yOrigin = imgplus.axis( yaxis ).calibratedValue( 0 );
-			}
-
-			final int zaxis = imgplus.dimensionIndex( Axes.Z );
-			if ( zaxis >= 0 )
-			{
-				impcal.pixelDepth = imgplus.averageScale( zaxis );
-				impcal.zOrigin = imgplus.axis( zaxis ).calibratedValue( 0 );
-			}
-
-			final int taxis = imgplus.dimensionIndex( Axes.TIME );
-			if ( taxis >= 0 )
-			{
-				impcal.frameInterval = imgplus.averageScale( taxis );
-			}
+			CalibrationUtils.copyCalibrationToImagePlus(imgplus, target);
 			target.setTitle( imgplus.getName() );
 		}
 

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
@@ -176,7 +176,7 @@ public class ImageJVirtualStack<S, T extends NativeType< T >> extends AbstractVi
 					origin = Views.hyperSlice( origin, 2, position[ i ] );
 			}
 
-			final Cursor< S > originCursor = Views.iterable( origin ).cursor();
+			final Cursor< S > originCursor = Views.flatIterable( origin ).cursor();
 			final Cursor< ? extends RealType<?> > cursor = createArrayImg( (int) source.dimension( 0 ), (int) source.dimension( 1 ), pixels).cursor();
 
 			// Replace the origin values with the current state of the virtual

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
@@ -69,18 +69,18 @@ public class ImageJVirtualStack<S, T extends NativeType< T >> extends AbstractVi
 	final private long[] higherSourceDimensions;
 	final private RandomAccessibleInterval< S > source;
 	private final T type;
-	private final Converter< S, T > converter;
+	private final Converter< ? super S, T > converter;
 	private boolean isWritable = false;
 	final protected ExecutorService service;
 
 	/* old constructor -> non-multithreaded projector */
-	protected ImageJVirtualStack(final RandomAccessibleInterval< S > source, final Converter< S, T > converter,
+	protected ImageJVirtualStack(final RandomAccessibleInterval< S > source, final Converter< ? super S, T > converter,
 			final T type, final int bitDepth)
 	{
 		this( source, converter, type, bitDepth, null );
 	}
 
-	protected ImageJVirtualStack(final RandomAccessibleInterval< S > source, final Converter< S, T > converter,
+	protected ImageJVirtualStack(final RandomAccessibleInterval< S > source, final Converter< ? super S, T > converter,
 			final T type, final int bitDepth, ExecutorService service)
 	{
 		super( (int) source.dimension( 0 ), (int) source.dimension( 1 ), multiply( initHigherDimensions( source ) ), bitDepth );

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
@@ -38,13 +38,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
-import ij.VirtualStack;
 import ij.process.ByteProcessor;
 import ij.process.ColorProcessor;
 import ij.process.FloatProcessor;
 import ij.process.ImageProcessor;
 import ij.process.ShortProcessor;
 import net.imglib2.Cursor;
+import net.imglib2.Interval;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converter;
 import net.imglib2.display.projector.AbstractProjector2D;
@@ -64,23 +64,14 @@ import net.imglib2.view.Views;
  * TODO
  * 
  */
-public abstract class ImageJVirtualStack<S, T extends NativeType< T >> extends VirtualStack
+public class ImageJVirtualStack<S, T extends NativeType< T >> extends AbstractVirtualStack
 {
-	final private int size;
 	final private long[] higherSourceDimensions;
-
-	final private int bitDepth;
-
 	final private RandomAccessibleInterval< S > source;
-
 	private final T type;
-
 	private final Converter< S, T > converter;
-
 	private boolean isWritable = false;
-
 	final protected ExecutorService service;
-
 	private double min = 0.0;
 	private double max = 1.0;
 
@@ -94,21 +85,24 @@ public abstract class ImageJVirtualStack<S, T extends NativeType< T >> extends V
 	protected ImageJVirtualStack(final RandomAccessibleInterval< S > source, final Converter< S, T > converter,
 			final T type, final int bitDepth, ExecutorService service)
 	{
-		super( (int) source.dimension( 0 ), (int) source.dimension( 1 ), null, null );
+		super( (int) source.dimension( 0 ), (int) source.dimension( 1 ), multiply( initHigherDimensions( source ) ), bitDepth );
 		// if the source interval is not zero-min, we wrap it into a view that
 		// translates it to the origin
 		// if we were given an ExecutorService, use a multithreaded projector
 		assert source.numDimensions() > 1;
 		this.source = zeroMin( source );
 		this.higherSourceDimensions = initHigherDimensions( source );
-		this.size = ( int ) LongStream.of(higherSourceDimensions).reduce( 1, (a, b) -> a * b );
 		this.type = type;
 		this.converter = converter;
 		this.service = service;
-		this.bitDepth = bitDepth;
 	}
 
-	private long[] initHigherDimensions( RandomAccessibleInterval< S > source )
+	private static int multiply( long[] higherSourceDimensions )
+	{
+		return ( int ) LongStream.of( higherSourceDimensions ).reduce( 1, (a, b) -> a * b );
+	}
+
+	private static long[] initHigherDimensions( Interval source )
 	{
 		return IntStream.range(2, source.numDimensions())
 				.mapToLong( source::dimension )
@@ -191,68 +185,11 @@ public abstract class ImageJVirtualStack<S, T extends NativeType< T >> extends V
 		return img;
 	}
 
-	@Override
-	public int getBitDepth()
-	{
-		return bitDepth;
-	}
-
-	/** Obsolete. Short images are always unsigned. */
-	@Override
-	public void addUnsignedShortSlice(final String sliceLabel, final Object pixels)
-	{
-	}
-
-	/** Adds the image in 'ip' to the end of the stack. */
-	@Override
-	public void addSlice(final String sliceLabel, final ImageProcessor ip)
-	{
-	}
-
-	/**
-	 * Adds the image in 'ip' to the stack following slice 'n'. Adds the slice
-	 * to the beginning of the stack if 'n' is zero.
-	 */
-	@Override
-	public void addSlice(final String sliceLabel, final ImageProcessor ip, final int n)
-	{
-	}
-
-	/** Deletes the specified slice, where {@code 1<=n<=nslices}. */
-	@Override
-	public void deleteSlice(final int n)
-	{
-	}
-
-	/** Deletes the last slice in the stack. */
-	@Override
-	public void deleteLastSlice()
-	{
-	}
-
-	/**
-	 * Updates this stack so its attributes, such as min, max, calibration table
-	 * and color model, are the same as 'ip'.
-	 */
-	@Override
-	public void update(final ImageProcessor ip)
-	{
-	}
-
-	/**
-	 * Returns the pixel array for the specified slice, where
-	 * {@code 1<=n<=nslices}.
-	 */
-	@Override
-	public Object getPixels(final int n)
+	@Override public Object getPixels( int n )
 	{
 		return getProcessor( n ).getPixels();
 	}
 
-	/**
-	 * Assigns a pixel array to the specified slice, where
-	 * {@code 1<=n<=nslices}.
-	 */
 	@Override
 	public void setPixels(final Object pixels, final int n)
 	{
@@ -285,7 +222,7 @@ public abstract class ImageJVirtualStack<S, T extends NativeType< T >> extends V
 		}
 	}
 
-	private Img< ? extends RealType<?> > createArrayImg( int sizeX, int sizeY, Object pixels ) {
+	private static Img< ? extends RealType<?> > createArrayImg( int sizeX, int sizeY, Object pixels ) {
 		if( pixels instanceof byte[] )
 			return ArrayImgs.unsignedBytes( (byte[]) pixels, sizeX, sizeY);
 		if( pixels instanceof short[] )
@@ -293,109 +230,5 @@ public abstract class ImageJVirtualStack<S, T extends NativeType< T >> extends V
 		if( pixels instanceof float[] )
 			return ArrayImgs.floats( (float[]) pixels, sizeX, sizeY);
 		throw new IllegalArgumentException( "unsupported pixel type" );
-	}
-
-	/**
-	 * Returns the stack as an array of 1D pixel arrays. Note that the size of
-	 * the returned array may be greater than the number of slices currently in
-	 * the stack, with unused elements set to null.
-	 */
-	@Override
-	public Object[] getImageArray()
-	{
-		return null;
-	}
-
-	/**
-	 * Returns the slice labels as an array of Strings. Note that the size of
-	 * the returned array may be greater than the number of slices currently in
-	 * the stack. Returns null if the stack is empty or the label of the first
-	 * slice is null.
-	 */
-	@Override
-	public String[] getSliceLabels()
-	{
-		return null;
-	}
-
-	/**
-	 * Returns the label of the specified slice, where {@code 1<=n<=nslices}.
-	 * Returns null if the slice does not have a label. For DICOM and FITS
-	 * stacks, labels may contain header information.
-	 */
-	@Override
-	public String getSliceLabel(final int n)
-	{
-		return "" + n;
-	}
-
-	/**
-	 * Returns a shortened version (up to the first 60 characters or first
-	 * newline and suffix removed) of the label of the specified slice. Returns
-	 * null if the slice does not have a label.
-	 */
-	@Override
-	public String getShortSliceLabel(final int n)
-	{
-		return getSliceLabel( n );
-	}
-
-	/** Sets the label of the specified slice, where {@code 1<=n<=nslices}. */
-	@Override
-	public void setSliceLabel(final String label, final int n)
-	{
-	}
-
-	/** Returns true if this is a 3-slice RGB stack. */
-	@Override
-	public boolean isRGB()
-	{
-		return false;
-	}
-
-	/** Returns true if this is a 3-slice HSB stack. */
-	@Override
-	public boolean isHSB()
-	{
-		return false;
-	}
-
-	/**
-	 * Returns true if this is a virtual (disk resident) stack. This method is
-	 * overridden by the VirtualStack subclass.
-	 */
-	@Override
-	public boolean isVirtual()
-	{
-		return true;
-	}
-
-	/** Frees memory by deleting a few slices from the end of the stack. */
-	@Override
-	public void trim()
-	{
-	}
-
-	@Override
-	public int getSize()
-	{
-		return size;
-	}
-
-	@Override
-	public void setBitDepth(final int bitDepth)
-	{
-	}
-
-	@Override
-	public String getDirectory()
-	{
-		return null;
-	}
-
-	@Override
-	public String getFileName(final int n)
-	{
-		return null;
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
@@ -36,7 +36,6 @@ package net.imglib2.img.display.imagej;
 
 import java.util.concurrent.ExecutorService;
 
-import ij.ImagePlus;
 import ij.VirtualStack;
 import ij.process.ByteProcessor;
 import ij.process.ColorProcessor;
@@ -86,13 +85,13 @@ public abstract class ImageJVirtualStack<S, T extends NativeType< T >> extends V
 
 	/* old constructor -> non-multithreaded projector */
 	protected ImageJVirtualStack(final RandomAccessibleInterval< S > source, final Converter< S, T > converter,
-			final T type, final int ijtype)
+			final T type, final int bitDepth)
 	{
-		this( source, converter, type, ijtype, null );
+		this( source, converter, type, bitDepth, null );
 	}
 
 	protected ImageJVirtualStack(final RandomAccessibleInterval< S > source, final Converter< S, T > converter,
-			final T type, final int ijtype, ExecutorService service)
+			final T type, final int bitDepth, ExecutorService service)
 	{
 		super( (int) source.dimension( 0 ), (int) source.dimension( 1 ), null, null );
 
@@ -117,7 +116,7 @@ public abstract class ImageJVirtualStack<S, T extends NativeType< T >> extends V
 
 		this.converter = converter;
 		this.service = service;
-		this.bitDepth = initBitDepth( ijtype );
+		this.bitDepth = bitDepth;
 	}
 
 	protected void setMinAndMax( double min, double max ) {
@@ -144,21 +143,6 @@ public abstract class ImageJVirtualStack<S, T extends NativeType< T >> extends V
 		if( storageArray instanceof float[] )
 			return new FloatProcessor( sizeX, sizeY, (float[]) storageArray, null );
 		throw new IllegalArgumentException( "unsupported color type" );
-	}
-
-	private int initBitDepth( int ijtype )
-	{
-		switch ( ijtype ) {
-		case ImagePlus.GRAY8:
-			return 8;
-		case ImagePlus.GRAY16:
-			return 16;
-		case ImagePlus.COLOR_RGB:
-			return 24;
-		case ImagePlus.GRAY32:
-			return 32;
-		}
-		throw new IllegalArgumentException( "unsupported color type " + ijtype );
 	}
 
 	/**

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackARGB.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackARGB.java
@@ -47,11 +47,11 @@ import net.imglib2.type.numeric.ARGBType;
  */
 public class ImageJVirtualStackARGB< S > extends ImageJVirtualStack< S, ARGBType >
 {
-	public ImageJVirtualStackARGB( RandomAccessibleInterval< S > source, Converter< S, ARGBType > converter)
+	public ImageJVirtualStackARGB( RandomAccessibleInterval< S > source, Converter< ? super S, ARGBType > converter)
 	{
 		this(source, converter, null);
 	}
-	public ImageJVirtualStackARGB( RandomAccessibleInterval< S > source, Converter< S, ARGBType > converter, ExecutorService service )
+	public ImageJVirtualStackARGB( RandomAccessibleInterval< S > source, Converter< ? super S, ARGBType > converter, ExecutorService service )
 	{
 		super( source, converter, new ARGBType(), 24, service);
 		setMinAndMax( 0, 255 );

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackARGB.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackARGB.java
@@ -54,6 +54,6 @@ public class ImageJVirtualStackARGB< S > extends ImageJVirtualStack< S, ARGBType
 	public ImageJVirtualStackARGB( RandomAccessibleInterval< S > source, Converter< S, ARGBType > converter, ExecutorService service )
 	{
 		super( source, converter, new ARGBType(), ImagePlus.COLOR_RGB, service);
-		imageProcessor.setMinAndMax( 0, 255 );
+		setMinAndMax( 0, 255 );
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackARGB.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackARGB.java
@@ -53,7 +53,7 @@ public class ImageJVirtualStackARGB< S > extends ImageJVirtualStack< S, ARGBType
 	}
 	public ImageJVirtualStackARGB( RandomAccessibleInterval< S > source, Converter< S, ARGBType > converter, ExecutorService service )
 	{
-		super( source, converter, new ARGBType(), ImagePlus.COLOR_RGB, service);
+		super( source, converter, new ARGBType(), 24, service);
 		setMinAndMax( 0, 255 );
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackFloat.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackFloat.java
@@ -65,7 +65,7 @@ public class ImageJVirtualStackFloat<S> extends ImageJVirtualStack< S, FloatType
 			final Converter< S, FloatType > converter, ExecutorService service)
 	{
 		super( source, converter, new FloatType(), ImagePlus.GRAY32, service );
-		imageProcessor.setMinAndMax( 0, 1 );
+		setMinAndMax( 0, 1 );
 	}
 
 	public void setMinMax(final RandomAccessibleInterval< S > source, final Converter< S, FloatType > converter)
@@ -101,7 +101,7 @@ public class ImageJVirtualStackFloat<S> extends ImageJVirtualStack< S, FloatType
 
 			System.out.println( "fmax = " + max );
 			System.out.println( "fmin = " + min );
-			imageProcessor.setMinAndMax( min, max );
+			setMinAndMax( min, max );
 		}
 	}
 
@@ -190,7 +190,7 @@ public class ImageJVirtualStackFloat<S> extends ImageJVirtualStack< S, FloatType
 
 		System.out.println( "fmax = " + max );
 		System.out.println( "fmin = " + min );
-		imageProcessor.setMinAndMax( min, max );
+		setMinAndMax( min, max );
 
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackFloat.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackFloat.java
@@ -64,7 +64,7 @@ public class ImageJVirtualStackFloat<S> extends ImageJVirtualStack< S, FloatType
 	public ImageJVirtualStackFloat(final RandomAccessibleInterval< S > source,
 			final Converter< S, FloatType > converter, ExecutorService service)
 	{
-		super( source, converter, new FloatType(), ImagePlus.GRAY32, service );
+		super( source, converter, new FloatType(), 32, service );
 		setMinAndMax( 0, 1 );
 	}
 

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackFloat.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackFloat.java
@@ -99,8 +99,6 @@ public class ImageJVirtualStackFloat<S> extends ImageJVirtualStack< S, FloatType
 					max = value;
 			}
 
-			System.out.println( "fmax = " + max );
-			System.out.println( "fmin = " + min );
 			setMinAndMax( min, max );
 		}
 	}
@@ -188,8 +186,6 @@ public class ImageJVirtualStackFloat<S> extends ImageJVirtualStack< S, FloatType
 				max = maxs.get( t );
 		}
 
-		System.out.println( "fmax = " + max );
-		System.out.println( "fmin = " + min );
 		setMinAndMax( min, max );
 
 	}

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackFloat.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackFloat.java
@@ -42,9 +42,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import ij.ImagePlus;
+import ij.VirtualStack;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converter;
+import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.view.RandomAccessibleIntervalCursor;
 import net.imglib2.view.Views;
@@ -55,6 +56,10 @@ import net.imglib2.view.Views;
  */
 public class ImageJVirtualStackFloat<S> extends ImageJVirtualStack< S, FloatType >
 {
+	public static < T extends RealType<?> > ImageJVirtualStackFloat<T> wrap( RandomAccessibleInterval<T> source ) {
+		return new ImageJVirtualStackFloat<>( source, new FloatConverter() );
+	}
+
 	public ImageJVirtualStackFloat(final RandomAccessibleInterval< S > source,
 			final Converter< ? super S, FloatType > converter)
 	{
@@ -187,6 +192,20 @@ public class ImageJVirtualStackFloat<S> extends ImageJVirtualStack< S, FloatType
 		}
 
 		setMinAndMax( min, max );
+
+	}
+
+	private static class FloatConverter implements
+			Converter<RealType<?>, FloatType >
+	{
+
+		@Override
+		public void convert(final RealType<?> input, final FloatType output) {
+			double val = input.getRealDouble();
+			if (val < -Float.MAX_VALUE) val = -Float.MAX_VALUE;
+			else if (val > Float.MAX_VALUE) val = Float.MAX_VALUE;
+			output.setReal(val);
+		}
 
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackFloat.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackFloat.java
@@ -56,13 +56,13 @@ import net.imglib2.view.Views;
 public class ImageJVirtualStackFloat<S> extends ImageJVirtualStack< S, FloatType >
 {
 	public ImageJVirtualStackFloat(final RandomAccessibleInterval< S > source,
-			final Converter< S, FloatType > converter)
+			final Converter< ? super S, FloatType > converter)
 	{
 		this( source, converter, null );
 	}
 
 	public ImageJVirtualStackFloat(final RandomAccessibleInterval< S > source,
-			final Converter< S, FloatType > converter, ExecutorService service)
+			final Converter< ? super S, FloatType > converter, ExecutorService service)
 	{
 		super( source, converter, new FloatType(), 32, service );
 		setMinAndMax( 0, 1 );

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
@@ -53,7 +53,7 @@ public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< S, 
 	}
 	public ImageJVirtualStackUnsignedByte( RandomAccessibleInterval< S > source, Converter< S, UnsignedByteType > converter, ExecutorService service )
 	{
-		super( source, converter, new UnsignedByteType(), ImagePlus.GRAY8 , service);
+		super( source, converter, new UnsignedByteType(), 8 , service);
 		setMinAndMax( 0, 255 );
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
@@ -37,8 +37,10 @@ package net.imglib2.img.display.imagej;
 import java.util.concurrent.ExecutorService;
 
 import ij.ImagePlus;
+import ij.VirtualStack;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converter;
+import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 
 /**
@@ -47,6 +49,10 @@ import net.imglib2.type.numeric.integer.UnsignedByteType;
  */
 public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< S, UnsignedByteType >
 {
+	public static <T extends RealType<?>> ImageJVirtualStackUnsignedByte<T> wrap( RandomAccessibleInterval<T> source ) {
+		return new ImageJVirtualStackUnsignedByte<T>( source, new ByteConverter() );
+	}
+
 	public ImageJVirtualStackUnsignedByte( RandomAccessibleInterval< S > source, Converter< ? super S, UnsignedByteType > converter)
 	{
 		this( source, converter, null );
@@ -55,5 +61,18 @@ public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< S, 
 	{
 		super( source, converter, new UnsignedByteType(), 8 , service);
 		setMinAndMax( 0, 255 );
+	}
+
+	private static class ByteConverter implements
+			Converter<RealType<?>, UnsignedByteType>
+	{
+
+		@Override
+		public void convert(final RealType<?> input, final UnsignedByteType output) {
+			double val = input.getRealDouble();
+			if (val < 0) val = 0;
+			else if (val > 255) val = 255;
+			output.setReal(val);
+		}
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
@@ -54,6 +54,6 @@ public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< S, 
 	public ImageJVirtualStackUnsignedByte( RandomAccessibleInterval< S > source, Converter< S, UnsignedByteType > converter, ExecutorService service )
 	{
 		super( source, converter, new UnsignedByteType(), ImagePlus.GRAY8 , service);
-		imageProcessor.setMinAndMax( 0, 255 );
+		setMinAndMax( 0, 255 );
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
@@ -47,11 +47,11 @@ import net.imglib2.type.numeric.integer.UnsignedByteType;
  */
 public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< S, UnsignedByteType >
 {
-	public ImageJVirtualStackUnsignedByte( RandomAccessibleInterval< S > source, Converter< S, UnsignedByteType > converter)
+	public ImageJVirtualStackUnsignedByte( RandomAccessibleInterval< S > source, Converter< ? super S, UnsignedByteType > converter)
 	{
 		this( source, converter, null );
 	}
-	public ImageJVirtualStackUnsignedByte( RandomAccessibleInterval< S > source, Converter< S, UnsignedByteType > converter, ExecutorService service )
+	public ImageJVirtualStackUnsignedByte( RandomAccessibleInterval< S > source, Converter< ? super S, UnsignedByteType > converter, ExecutorService service )
 	{
 		super( source, converter, new UnsignedByteType(), 8 , service);
 		setMinAndMax( 0, 255 );

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
@@ -40,6 +40,7 @@ import ij.ImagePlus;
 import ij.VirtualStack;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converter;
+import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 
@@ -50,7 +51,11 @@ import net.imglib2.type.numeric.integer.UnsignedByteType;
 public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< S, UnsignedByteType >
 {
 	public static <T extends RealType<?>> ImageJVirtualStackUnsignedByte<T> wrap( RandomAccessibleInterval<T> source ) {
-		return new ImageJVirtualStackUnsignedByte<T>( source, new ByteConverter() );
+		return new ImageJVirtualStackUnsignedByte<>( source, new ByteConverter() );
+	}
+
+	public static ImageJVirtualStackUnsignedByte<BitType> wrapAndScaleBitType( RandomAccessibleInterval<BitType> source ) {
+		return new ImageJVirtualStackUnsignedByte<>( source, new BitToByteConverter() );
 	}
 
 	public ImageJVirtualStackUnsignedByte( RandomAccessibleInterval< S > source, Converter< ? super S, UnsignedByteType > converter)
@@ -73,6 +78,16 @@ public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< S, 
 			if (val < 0) val = 0;
 			else if (val > 255) val = 255;
 			output.setReal(val);
+		}
+	}
+
+	private static class BitToByteConverter implements
+			Converter<BitType, UnsignedByteType>
+	{
+
+		@Override
+		public void convert(final BitType input, final UnsignedByteType output) {
+			output.set(input.get() ? 255 : 0);
 		}
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedShort.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedShort.java
@@ -57,7 +57,7 @@ public class ImageJVirtualStackUnsignedShort< S > extends ImageJVirtualStack< S,
 
 	public ImageJVirtualStackUnsignedShort( RandomAccessibleInterval< S > source, Converter< S, UnsignedShortType > converter, ExecutorService service )
 	{
-		super( source, converter, new UnsignedShortType(), ImagePlus.GRAY16, service );
+		super( source, converter, new UnsignedShortType(), 16, service );
 
 		int maxDisplay = (1 << 16) - 1;
 		

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedShort.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedShort.java
@@ -50,12 +50,12 @@ import net.imglib2.util.Util;
  */
 public class ImageJVirtualStackUnsignedShort< S > extends ImageJVirtualStack< S, UnsignedShortType >
 {
-	public ImageJVirtualStackUnsignedShort( RandomAccessibleInterval< S > source, Converter< S, UnsignedShortType > converter)
+	public ImageJVirtualStackUnsignedShort( RandomAccessibleInterval< S > source, Converter< ? super S, UnsignedShortType > converter)
 	{
 		this( source, converter, null );
 	}
 
-	public ImageJVirtualStackUnsignedShort( RandomAccessibleInterval< S > source, Converter< S, UnsignedShortType > converter, ExecutorService service )
+	public ImageJVirtualStackUnsignedShort( RandomAccessibleInterval< S > source, Converter< ? super S, UnsignedShortType > converter, ExecutorService service )
 	{
 		super( source, converter, new UnsignedShortType(), 16, service );
 

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedShort.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedShort.java
@@ -36,10 +36,10 @@ package net.imglib2.img.display.imagej;
 
 import java.util.concurrent.ExecutorService;
 
-import ij.ImagePlus;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.Unsigned12BitType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.util.Util;
@@ -50,6 +50,10 @@ import net.imglib2.util.Util;
  */
 public class ImageJVirtualStackUnsignedShort< S > extends ImageJVirtualStack< S, UnsignedShortType >
 {
+	public static < T extends RealType<?> > ImageJVirtualStackUnsignedShort< T > wrap( RandomAccessibleInterval< T > source ) {
+		return new ImageJVirtualStackUnsignedShort<>( source, new ShortConverter() );
+	}
+
 	public ImageJVirtualStackUnsignedShort( RandomAccessibleInterval< S > source, Converter< ? super S, UnsignedShortType > converter)
 	{
 		this( source, converter, null );
@@ -69,5 +73,19 @@ public class ImageJVirtualStackUnsignedShort< S > extends ImageJVirtualStack< S,
 			maxDisplay = 4095;
 		
 		setMinAndMax( 0, maxDisplay );
+	}
+
+	private static class ShortConverter implements
+			Converter<RealType<?>, UnsignedShortType >
+	{
+
+		@Override
+		public void convert(final RealType<?> input, final UnsignedShortType output) {
+			double val = input.getRealDouble();
+			if (val < 0) val = 0;
+			else if (val > 65535) val = 65535;
+			output.setReal(val);
+		}
+
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedShort.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedShort.java
@@ -68,6 +68,6 @@ public class ImageJVirtualStackUnsignedShort< S > extends ImageJVirtualStack< S,
 		else if ( Unsigned12BitType.class.isInstance( s ) )
 			maxDisplay = 4095;
 		
-		imageProcessor.setMinAndMax( 0, maxDisplay );
+		setMinAndMax( 0, maxDisplay );
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageProcessorUtils.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageProcessorUtils.java
@@ -1,0 +1,76 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.display.imagej;
+
+import ij.process.ByteProcessor;
+import ij.process.ColorProcessor;
+import ij.process.FloatProcessor;
+import ij.process.ImageProcessor;
+import ij.process.ShortProcessor;
+import net.imglib2.type.Type;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.FloatType;
+
+import java.awt.image.ColorModel;
+
+public class ImageProcessorUtils
+{
+	private ImageProcessorUtils()
+	{
+		// prevent from instantiation
+	}
+
+	public static ImageProcessor initProcessor( int sizeX, int sizeY, Object pixels, ColorModel colorModel )
+	{
+		if ( pixels instanceof byte[] )
+			return new ByteProcessor( sizeX, sizeY, ( byte[] ) pixels, colorModel );
+		if ( pixels instanceof short[] )
+			return new ShortProcessor( sizeX, sizeY, ( short[] ) pixels, colorModel );
+		if ( pixels instanceof int[] )
+			return new ColorProcessor( sizeX, sizeY, ( int[] ) pixels );
+		if ( pixels instanceof float[] )
+			return new FloatProcessor( sizeX, sizeY, ( float[] ) pixels, colorModel );
+		throw new IllegalArgumentException( "unsupported color type" );
+	}
+
+	public static boolean isSupported( Type< ? > type )
+	{
+		return ( type instanceof UnsignedByteType ) || ( type instanceof UnsignedShortType ) ||
+				( type instanceof ARGBType ) || ( type instanceof FloatType);
+	}
+}

--- a/src/main/java/net/imglib2/img/display/imagej/ImgPlusViews.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImgPlusViews.java
@@ -1,0 +1,155 @@
+/*-
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.display.imagej;
+
+import net.imagej.ImgPlus;
+import net.imagej.axis.Axes;
+import net.imglib2.RandomAccessible;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.converter.Converters;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgView;
+import net.imglib2.type.Type;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+import net.imglib2.view.composite.Composite;
+
+import java.util.function.IntUnaryOperator;
+
+// TODO: migrate to imagej-common
+public class ImgPlusViews {
+
+	/**
+	 * Same as {@link Views#hyperSlice(RandomAccessible, int, long)}.
+	 * But works on {@link ImgPlus} and manages axes information too.
+	 */
+	public static <T extends Type<T>> ImgPlus<T> hyperSlice(ImgPlus<T> image, int d, long position) {
+		IntUnaryOperator axesMapping = i -> (i < d) ? i : i + 1;
+		return newImgPlus( image, Views.hyperSlice( image.getImg(), d, position ), axesMapping );
+	}
+
+	/**
+	 * Same as {@link Views#permute(RandomAccessible, int, int)}. But works on {@link ImgPlus}.
+	 * But works on {@link ImgPlus} and manages axes information too.
+	 */
+	public static <T extends Type<T>> ImgPlus<T> permute(ImgPlus<T> image, int fromAxis, int toAxis) {
+		if(fromAxis == toAxis)
+			return image;
+		IntUnaryOperator axesMapping = i -> {
+			if(i == fromAxis) return toAxis;
+			if(i == toAxis) return fromAxis;
+			return i;
+		};
+		return newImgPlus( image, Views.permute( image.getImg(), fromAxis, toAxis ), axesMapping );
+	}
+
+	/**
+	 * Permutes the axes of the image. One axis is moved, while the order of the other axes is preserved.
+	 * If an image has axis order XYCZT, fromAxis=2 and toAxis=4, then the returned axis order is XYZTC.
+	 */
+	public static <T extends Type<T>> ImgPlus<T> moveAxis(ImgPlus<T> image, int fromAxis, int toAxis) {
+		if(fromAxis == toAxis)
+			return image;
+		int direction = toAxis > fromAxis ? 1 : -1;
+		ImgPlus<T> res = image;
+		for ( int i = fromAxis; i != toAxis; i += direction)
+			res = permute(res, i, i + direction);
+		return res;
+	}
+
+	/**
+	 * Indicates it {@link #fuseColor(ImgPlus)} can by used.
+	 */
+	public static boolean canFuseColor( ImgPlus< ? extends RealType< ? > > image) {
+		int d = image.dimensionIndex( Axes.CHANNEL );
+		return d >= 0 && image.dimension( d ) == 3;
+	}
+
+	/**
+	 * Generates a color image from a gray scale image that has a color axes of dimension 3.
+	 */
+	public static ImgPlus< ARGBType > fuseColor( ImgPlus< ? extends RealType<?>> image) {
+		int d = image.dimensionIndex( Axes.CHANNEL );
+		RandomAccessibleInterval< ARGBType > colors = fuseColor( image.getImg(), d );
+		IntUnaryOperator axisMapping = i -> ( i < d ) ? i : i + 1;
+		return newImgPlus( image, colors, axisMapping );
+	}
+
+	private static RandomAccessibleInterval< ARGBType > fuseColor( Img< ? extends RealType< ? > > image, int d )
+	{
+		if ( d < 0 || image.dimension( d ) != 3 )
+			throw new IllegalArgumentException();
+		return Converters.convert(
+				Views.collapse( moveAxis( image, d, image.numDimensions() - 1 ) ),
+				ImgPlusViews::convertToColor,
+				new ARGBType()
+		);
+	}
+
+	// -- Helper methods --
+
+	private static < T extends Type< T > > ImgPlus< T > newImgPlus( ImgPlus< ? > image, RandomAccessibleInterval< T > newContent, IntUnaryOperator axesMapping )
+	{
+		T type = Util.getTypeFromInterval( newContent );
+		Img< T > newImg = ImgView.wrap( newContent, image.factory().imgFactory( type ) );
+		ImgPlus< T > result = new ImgPlus<>( newImg, image.getName() );
+		for ( int i = 0; i < result.numDimensions(); i++ )
+			result.setAxis( image.axis( axesMapping.applyAsInt( i ) ).copy(), i );
+		return result;
+	}
+
+	// TODO: move to imglib2 Views
+	private static < T > RandomAccessibleInterval< T > moveAxis( RandomAccessibleInterval< T > image, int fromAxis, int toAxis )
+	{
+		if ( fromAxis == toAxis )
+			return image;
+		int direction = toAxis > fromAxis ? 1 : -1;
+		RandomAccessibleInterval< T > res = image;
+		for ( int i = fromAxis; i != toAxis; i += direction )
+			res = Views.permute( res, i, i + direction );
+		return res;
+	}
+
+	private static void convertToColor( Composite< ? extends RealType< ? > > in, ARGBType out )
+	{
+		out.set( ARGBType.rgba( toInt( in.get( 0 ) ), toInt( in.get( 1 ) ), toInt( in.get( 2 ) ), 255 ) );
+	}
+
+	private static int toInt( RealType< ? > realType )
+	{
+		return ( int ) realType.getRealFloat();
+	}
+}

--- a/src/main/java/net/imglib2/img/display/imagej/ImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImgToVirtualStack.java
@@ -46,13 +46,8 @@ import net.imglib2.type.numeric.RealType;
 import net.imglib2.view.MixedTransformView;
 import net.imglib2.view.Views;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -66,6 +61,7 @@ public class ImgToVirtualStack
 
 	public static ImagePlus wrap( ImgPlus< ? > imgPlus )
 	{
+		imgPlus = ImgPlusViews.fixAxes( imgPlus );
 		RandomAccessibleInterval<?> sorted = ensureXYCZT(imgPlus);
 		ImageStack stack = createVirtualStack(sorted);
 		ImagePlus result = new ImagePlus( imgPlus.getName(), stack );

--- a/src/main/java/net/imglib2/img/display/imagej/ImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImgToVirtualStack.java
@@ -64,7 +64,7 @@ public class ImgToVirtualStack
 		return wrap( imgPlus2 );
 	}
 
-	private static ImagePlus wrap( ImgPlus< ? > imgPlus )
+	public static ImagePlus wrap( ImgPlus< ? > imgPlus )
 	{
 		RandomAccessibleInterval<?> sorted = ensureXYCZT(imgPlus);
 		ImageStack stack = createVirtualStack(sorted);

--- a/src/main/java/net/imglib2/img/display/imagej/ImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImgToVirtualStack.java
@@ -55,17 +55,37 @@ import java.util.stream.IntStream;
 
 public class ImgToVirtualStack
 {
+	// TODO move to image-legacy
 	public static ImagePlus wrap( ImgPlus< ? extends RealType< ? > > imgPlus, boolean mergeRGB )
 	{
 		ImgPlus< ? > imgPlus2 = mergeRGB && ImgPlusViews.canFuseColor( imgPlus ) ? ImgPlusViews.fuseColor( imgPlus ) : imgPlus;
 		return wrap( imgPlus2 );
 	}
 
+	/**
+	 * Wraps an {@link ImgPlus} into an {@link ImagePlus}.
+	 * The image can be {@link RealType} or {@link ARGBType}.
+	 * The {@link ImagePlus} is backed by a special {@link ij.VirtualStack},
+	 * which copies an plane from the given image, instead of it plane from a file.
+	 * <p>
+	 * Only up to five dimensions are support. Axes can might be arbitrary.
+	 * The image title and calibration are derived from the given image.
+	 *
+	 * @see ArrayImgToVirtualStack
+	 * @see ImgToVirtualStack
+	 */
 	public static ImagePlus wrap( ImgPlus< ? > imgPlus )
 	{
 		return wrap( imgPlus, ImgToVirtualStack::createVirtualStack );
 	}
 
+	/**
+	 * Similar to {@link #wrap(ImgPlus)}, but works only for {@link ImgPlus} of {@link BitType}.
+	 * The pixel values of 0 and 1 are scaled to 0 and 255.
+	 *
+	 * @see ArrayImgToVirtualStack
+	 * @see ImgToVirtualStack
+	 */
 	public static ImagePlus wrapAndScaleBitType( ImgPlus<BitType > imgPlus )
 	{
 		return wrap( imgPlus, ImgToVirtualStack::createVirtualStackBits );

--- a/src/main/java/net/imglib2/img/display/imagej/ImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImgToVirtualStack.java
@@ -70,6 +70,7 @@ public class ImgToVirtualStack
 		ImageStack stack = createVirtualStack(sorted);
 		ImagePlus result = new ImagePlus( imgPlus.getName(), stack );
 		result.setDimensions( (int) sorted.dimension(2), (int) sorted.dimension(3), (int) sorted.dimension(4) );
+		CalibrationUtils.copyCalibrationToImagePlus(imgPlus, result);
 		return result;
 	}
 

--- a/src/main/java/net/imglib2/img/display/imagej/ImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImgToVirtualStack.java
@@ -1,0 +1,165 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.display.imagej;
+
+import ij.ImagePlus;
+import ij.ImageStack;
+import net.imagej.ImgPlus;
+import net.imagej.axis.Axes;
+import net.imagej.axis.AxisType;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.transform.integer.MixedTransform;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.MixedTransformView;
+import net.imglib2.view.Views;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class ImgToVirtualStack
+{
+	public static ImagePlus wrap( ImgPlus< ? extends RealType< ? > > imgPlus, boolean mergeRGB )
+	{
+		ImgPlus< ? > imgPlus2 = mergeRGB && ImgPlusViews.canFuseColor( imgPlus ) ? ImgPlusViews.fuseColor( imgPlus ) : imgPlus;
+		return wrap( imgPlus2 );
+	}
+
+	private static ImagePlus wrap( ImgPlus< ? > imgPlus )
+	{
+		RandomAccessibleInterval<?> sorted = ensureXYCZT(imgPlus);
+		ImageStack stack = createVirtualStack(sorted);
+		ImagePlus result = new ImagePlus( imgPlus.getName(), stack );
+		result.setDimensions( (int) sorted.dimension(2), (int) sorted.dimension(3), (int) sorted.dimension(4) );
+		return result;
+	}
+
+	private static ImageStack createVirtualStack( RandomAccessibleInterval< ? > rai )
+	{
+		final Object type = rai.randomAccess().get();
+		if( type instanceof RealType )
+		{
+			ImageJVirtualStack< ?, ? > result = createVirtualStackRealType( cast( rai ) );
+			result.setWritable( true );
+			return result;
+		}
+		if( type instanceof ARGBType )
+			return ImageJVirtualStackARGB.wrap( cast( rai ) );
+		throw new IllegalArgumentException( "Unsupported type" );
+	}
+
+	private static <T> T cast( Object in ) {
+		@SuppressWarnings( "unchecked" )
+		T out = ( T ) in;
+		return out;
+	}
+
+	private static ImageJVirtualStack< ?, ? > createVirtualStackRealType( RandomAccessibleInterval< ? extends RealType< ? > > rai )
+	{
+		final RealType<? extends RealType<?>> type = rai.randomAccess().get();
+		final int bitDepth = type.getBitsPerPixel();
+		final boolean isSigned = type.getMinValue() < 0;
+
+		if (bitDepth <= 8 && !isSigned)
+			return ImageJVirtualStackUnsignedByte.wrap( rai );
+		if (bitDepth <= 16 && !isSigned)
+			return ImageJVirtualStackUnsignedShort.wrap( rai );
+
+		// other types translated as 32-bit float data
+		return ImageJVirtualStackFloat.wrap( rai );
+	}
+
+	private static <T> RandomAccessibleInterval<T> ensureXYCZT(final ImgPlus<T> imgPlus) {
+		final int[] axes = getPermutation(getAxes(imgPlus));
+		return permute(imgPlus, axes);
+	}
+
+	private static int[] getPermutation(List<AxisType> axes) {
+		return axes.stream().mapToInt(axis -> {
+			int index = imagePlusAxisOrder.indexOf(axis);
+			if (index < 0)
+				throw new IllegalArgumentException("Unsupported axis type: " + axis);
+			return index;
+		}).toArray();
+	}
+
+	private static List<AxisType> getAxes(ImgPlus<?> imgPlus) {
+		return IntStream.range(0, imgPlus.numDimensions())
+				.mapToObj(i -> imgPlus.axis(i).type())
+				.collect(Collectors.toList());
+	}
+
+	private static <T> RandomAccessibleInterval<T> permute(ImgPlus<T> imgPlus, int[] axes) {
+		boolean inNaturalOrder = true;
+		final boolean[] matchedDimensions = new boolean[5];
+		final long[] min = new long[5], max = new long[5];
+		for (int d = 0; d < axes.length; d++) {
+			int index = axes[d];
+			matchedDimensions[index] = true;
+			min[index] = imgPlus.min(d);
+			max[index] = imgPlus.max(d);
+			if (index != d) inNaturalOrder = false;
+		}
+
+		if (imgPlus.numDimensions() != 5) inNaturalOrder = false;
+		if (inNaturalOrder) return imgPlus;
+
+		axes = Arrays.copyOf(axes, 5);
+		RandomAccessibleInterval<T> rai = imgPlus;
+		// pad the image to at least 5D
+		for (int i = 0; i < 5; i++) {
+			if (matchedDimensions[i]) continue;
+			axes[rai.numDimensions()] = i;
+			min[i] = 0;
+			max[i] = 0;
+			rai = Views.addDimension(rai, 0, 0);
+		}
+
+		// permute the axis order to XYCZT...
+		final MixedTransform t = new MixedTransform(rai.numDimensions(), 5);
+		t.setComponentMapping(axes);
+		return Views.interval(new MixedTransformView< >( rai, t ), min, max);
+	}
+
+	private static final List<AxisType > imagePlusAxisOrder =
+			Arrays.asList(Axes.X, Axes.Y, Axes.CHANNEL, Axes.Z, Axes.TIME);
+}

--- a/src/main/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStack.java
@@ -1,0 +1,209 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.display.imagej;
+
+import ij.ImagePlus;
+import ij.VirtualStack;
+import net.imagej.ImgPlus;
+import net.imagej.axis.Axes;
+import net.imagej.axis.AxisType;
+import net.imagej.axis.CalibratedAxis;
+import net.imglib2.Interval;
+import net.imglib2.img.Img;
+import net.imglib2.img.basictypeaccess.PlanarAccess;
+import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
+import net.imglib2.img.planar.PlanarImg;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.Type;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.IntervalIndexer;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.IntUnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class PlanarImgToVirtualStack extends AbstractVirtualStack
+{
+
+	// static
+
+	public static boolean isSupported( ImgPlus< ? > imgPlus )
+	{
+		return imgPlus.getImg() instanceof PlanarImg &&
+				checkAxisOrder( getAxes( imgPlus ) ) &&
+				ImageProcessorUtils.isSupported( ( NativeType< ? > ) imgPlus.randomAccess().get() );
+	}
+
+	public static ImagePlus wrap( ImgPlus< ? > imgPlus )
+	{
+		Img< ? > img = imgPlus.getImg();
+		if ( !( img instanceof PlanarImg ) )
+			throw new IllegalArgumentException( "Image must be a PlanarImg." );
+		IntUnaryOperator indexer = getIndexer( imgPlus );
+		VirtualStack stack = new PlanarImgToVirtualStack( ( PlanarImg< ?, ? > ) img, indexer );
+		ImagePlus imagePlus = new ImagePlus( imgPlus.getName(), stack );
+		imagePlus.setDimensions( dimension( imgPlus, Axes.CHANNEL ), dimension( imgPlus, Axes.Z ), dimension( imgPlus, Axes.TIME ) );
+		return imagePlus;
+	}
+
+	private static int dimension( ImgPlus imgPlus, AxisType axisType )
+	{
+		int index = imgPlus.dimensionIndex( axisType );
+		return index < 0 ? 1 : ( int ) imgPlus.dimension( index );
+	}
+
+	public static VirtualStack wrap( PlanarImg< ?, ? > img )
+	{
+		return new PlanarImgToVirtualStack( img, x -> x - 1 );
+	}
+
+	// fields
+
+	private final PlanarAccess< ? extends ArrayDataAccess< ? > > img;
+
+	private final IntUnaryOperator indexer;
+
+	// constructor
+
+	private PlanarImgToVirtualStack( PlanarImg< ?, ? > img, IntUnaryOperator indexer )
+	{
+		super( ( int ) img.dimension( 0 ), ( int ) img.dimension( 1 ), initSize( img ), getBitDepth( img.randomAccess().get() ) );
+		this.img = img;
+		this.indexer = indexer;
+	}
+
+	private static int initSize( Interval interval )
+	{
+		return IntStream.range( 2, interval.numDimensions() ).map( x -> ( int ) interval.dimension( x ) ).reduce( 1, ( a, b ) -> a * b );
+	}
+
+	// public methods
+
+	@Override
+	public Object getPixels( int n )
+	{
+		return img.getPlane( indexer.applyAsInt( n ) ).getCurrentStorageArray();
+	}
+
+	// Helper methods
+
+	private static int getBitDepth( Type< ? > type )
+	{
+		if ( type instanceof UnsignedByteType )
+			return 8;
+		if ( type instanceof UnsignedShortType )
+			return 16;
+		if ( type instanceof ARGBType )
+			return 24;
+		if ( type instanceof FloatType )
+			return 32;
+		throw new IllegalArgumentException( "unsupported type" );
+	}
+
+	private static IntUnaryOperator getIndexer( ImgPlus< ? > imgPlus )
+	{
+		List< AxisType > axes = getAxes( imgPlus );
+		if ( !checkAxisOrder( axes ) )
+			throw new IllegalArgumentException( "Unsupported axis order, first axis must be X, second axis must be Y, and then optionally, arbitrary ordered: channel, Z and time." );
+		if ( inPreferredOrder( axes ) )
+			return x -> x - 1;
+		int[] stackSizes = { dimension( imgPlus, Axes.CHANNEL ), dimension( imgPlus, Axes.Z ), dimension( imgPlus, Axes.TIME ) };
+		int channelSkip = getSkip( imgPlus, Axes.CHANNEL );
+		int zSkip = getSkip( imgPlus, Axes.Z );
+		int timeSkip = getSkip( imgPlus, Axes.TIME );
+		return stackIndex -> {
+			int[] stackPosition = new int[ 3 ];
+			IntervalIndexer.indexToPosition( stackIndex - 1, stackSizes, stackPosition );
+			return channelSkip * stackPosition[ 0 ] + zSkip * stackPosition[ 1 ] + timeSkip * stackPosition[ 2 ];
+		};
+	}
+
+	private static List< AxisType > getAxes( ImgPlus< ? > img )
+	{
+		return IntStream.range( 0, img.numDimensions() ).mapToObj( img::axis ).map( CalibratedAxis::type ).collect( Collectors.toList() );
+	}
+
+	private static boolean checkAxisOrder( List< AxisType > axes )
+	{
+		return axes.size() >= 2 && axes.size() <= 5 && testUnique( axes ) &&
+				axes.get( 0 ) == Axes.X && axes.get( 1 ) == Axes.Y &&
+				axes.stream().allMatch( ALLOWED_AXES::contains );
+	}
+
+	private static final List< AxisType > ALLOWED_AXES = Arrays.asList( Axes.X, Axes.Y, Axes.CHANNEL, Axes.Z, Axes.TIME );
+
+	private static boolean inPreferredOrder( List< AxisType > axes )
+	{
+		for ( int i = 0; i < axes.size() - 1; i++ )
+			if ( preferredPosition( axes.get( i ) ) >= preferredPosition( axes.get( i + 1 ) ) )
+				return false;
+		return true;
+	}
+
+	private static int preferredPosition( AxisType axisType )
+	{
+		if ( axisType == Axes.X )
+			return 0;
+		if ( axisType == Axes.Y )
+			return 1;
+		if ( axisType == Axes.CHANNEL )
+			return 2;
+		if ( axisType == Axes.Z )
+			return 3;
+		if ( axisType == Axes.TIME )
+			return 4;
+		throw new IllegalArgumentException( "unknown axis" );
+	}
+
+	private static int getSkip( ImgPlus< ? > imgPlus, AxisType axis )
+	{
+		int channelIndex = imgPlus.dimensionIndex( axis );
+		return IntStream.range( 2, channelIndex ).map( i -> ( int ) imgPlus.dimension( i ) ).reduce( 1, ( a, b ) -> a * b );
+	}
+
+	private static < T > boolean testUnique( List< T > list )
+	{
+		Set< T > set = new HashSet<>( list );
+		return set.size() == list.size();
+	}
+
+}

--- a/src/main/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStack.java
@@ -66,6 +66,12 @@ public class PlanarImgToVirtualStack extends AbstractVirtualStack
 
 	// static
 
+	/**
+	 * Returns true, if {@link #wrap(ImgPlus)} supports the given image.
+	 *
+	 * @see ArrayImgToVirtualStack
+	 * @see ImgToVirtualStack
+	 */
 	public static boolean isSupported( ImgPlus< ? > imgPlus )
 	{
 		imgPlus = ImgPlusViews.fixAxes( imgPlus );
@@ -74,6 +80,22 @@ public class PlanarImgToVirtualStack extends AbstractVirtualStack
 				ImageProcessorUtils.isSupported( ( NativeType< ? > ) imgPlus.randomAccess().get() );
 	}
 
+	/**
+	 * Wraps an {@link ImgPlus}, that is backed by an {@link PlanarImg} into and {@link ImagePlus}.
+	 * The returned {@link ImagePlus} uses the same pixel buffer as the given image.
+	 * Changes to the {@link ImagePlus} are therefore reflected in the {@link ImgPlus}.
+	 * <p>
+	 * The image must be {@link UnsignedByteType}, {@link UnsignedShortType}, {@link ARGBType} or {@link FloatType}.
+	 * Only up to five dimensions are support. Axes oder must start with X, Y axes.
+	 * Channel, Time and Z axes might follow in arbitrary order.
+	 * The image title and calibration are derived from the given image.
+	 * <p>
+	 * Use {@link #isSupported(ImgPlus)} to check if an {@link ImagePlus} is supported.
+	 *
+	 * @see #isSupported(ImgPlus)
+	 * @see ArrayImgToVirtualStack
+	 * @see ImgToVirtualStack
+	 */
 	public static ImagePlus wrap( ImgPlus< ? > imgPlus )
 	{
 		imgPlus = ImgPlusViews.fixAxes( imgPlus );

--- a/src/main/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStack.java
@@ -82,6 +82,7 @@ public class PlanarImgToVirtualStack extends AbstractVirtualStack
 		VirtualStack stack = new PlanarImgToVirtualStack( ( PlanarImg< ?, ? > ) img, indexer );
 		ImagePlus imagePlus = new ImagePlus( imgPlus.getName(), stack );
 		imagePlus.setDimensions( dimension( imgPlus, Axes.CHANNEL ), dimension( imgPlus, Axes.Z ), dimension( imgPlus, Axes.TIME ) );
+		CalibrationUtils.copyCalibrationToImagePlus( imgPlus, imagePlus );
 		return imagePlus;
 	}
 

--- a/src/main/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStack.java
@@ -68,6 +68,7 @@ public class PlanarImgToVirtualStack extends AbstractVirtualStack
 
 	public static boolean isSupported( ImgPlus< ? > imgPlus )
 	{
+		imgPlus = ImgPlusViews.fixAxes( imgPlus );
 		return imgPlus.getImg() instanceof PlanarImg &&
 				checkAxisOrder( getAxes( imgPlus ) ) &&
 				ImageProcessorUtils.isSupported( ( NativeType< ? > ) imgPlus.randomAccess().get() );
@@ -75,6 +76,7 @@ public class PlanarImgToVirtualStack extends AbstractVirtualStack
 
 	public static ImagePlus wrap( ImgPlus< ? > imgPlus )
 	{
+		imgPlus = ImgPlusViews.fixAxes( imgPlus );
 		Img< ? > img = imgPlus.getImg();
 		if ( !( img instanceof PlanarImg ) )
 			throw new IllegalArgumentException( "Image must be a PlanarImg." );

--- a/src/test/java/net/imglib2/img/ImagePlusToImgLib2Benchmark.java
+++ b/src/test/java/net/imglib2/img/ImagePlusToImgLib2Benchmark.java
@@ -1,0 +1,132 @@
+/*-
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img;
+
+import ij.ImagePlus;
+import ij.gui.NewImage;
+import net.imagej.ImgPlus;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.imageplus.ByteImagePlus;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.view.Views;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+@State( Scope.Benchmark )
+public class ImagePlusToImgLib2Benchmark
+{
+	private ImagePlus small = NewImage.createByteImage( "deep", 10, 10, 10, NewImage.FILL_BLACK );
+	private ImagePlus deep = NewImage.createByteImage( "deep", 10, 10, 1000000, NewImage.FILL_BLACK );
+	private ImagePlus wide = NewImage.createByteImage( "deep", 1000, 1000, 1000, NewImage.FILL_BLACK );
+	private ImagePlus imageForIteration = NewImage.createByteImage( "deep", 10, 10, 1000, NewImage.FILL_BLACK );
+
+	@Benchmark
+	public void wrapSmall() {
+		VirtualStackAdapter.wrap(small);
+	}
+
+	@Benchmark
+	public void wrapDeep() {
+		VirtualStackAdapter.wrap(deep);
+	}
+
+	@Benchmark
+	public void wrapWide() {
+		VirtualStackAdapter.wrap(wide);
+	}
+
+	@Benchmark
+	public void wrapSmallOld() {
+		ImagePlusAdapter.wrap(small);
+	}
+
+	@Benchmark
+	public void wrapDeepOld() {
+		ImagePlusAdapter.wrap(deep);
+	}
+
+	@Benchmark
+	public void wrapWideOld() {
+		ImagePlusAdapter.wrap(wide);
+	}
+
+	private final ImgPlus< UnsignedByteType > wrapped = VirtualStackAdapter.wrapByte( imageForIteration );
+	private final ByteImagePlus< UnsignedByteType > wrappedOld = ImagePlusAdapter.wrapByte( imageForIteration );
+
+	@Benchmark
+	public void iterateWrapped() {
+		flatIterate( wrapped );
+	}
+
+	@Benchmark
+	public void iterateWrappedOld() {
+		flatIterate( wrappedOld );
+	}
+
+	@Benchmark
+	public void iteratePermutedWrapped() {
+		flatIterate( Views.permute( wrapped, 0, 2 ) );
+	}
+
+	@Benchmark
+	public void iteratePermutedWrappedOld() {
+		flatIterate( Views.permute( wrappedOld, 0, 2 ) );
+	}
+
+
+	private <T> void flatIterate( RandomAccessibleInterval< T > image )
+	{
+		for( T pixel : Views.flatIterable( image ) )
+			;
+	}
+
+	public static void main( final String... args ) throws RunnerException
+	{
+		final Options opt = new OptionsBuilder()
+				.include( ImagePlusToImgLib2Benchmark.class.getSimpleName() )
+				.forks( 0 )
+				.warmupIterations( 4 )
+				.measurementIterations( 8 )
+				.warmupTime( TimeValue.milliseconds( 100 ) )
+				.measurementTime( TimeValue.milliseconds( 100 ) )
+				.build();
+		new Runner( opt ).run();
+	}
+}

--- a/src/test/java/net/imglib2/img/ImagePlusToImgLib2PerformanceTest.java
+++ b/src/test/java/net/imglib2/img/ImagePlusToImgLib2PerformanceTest.java
@@ -1,0 +1,96 @@
+/*-
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img;
+
+import ij.ImagePlus;
+import ij.VirtualStack;
+import ij.process.ByteProcessor;
+import ij.process.ImageProcessor;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.Views;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static junit.framework.TestCase.assertTrue;
+
+public class ImagePlusToImgLib2PerformanceTest
+{
+
+	@Test
+	public void testIterateVirtualStack() {
+		AtomicInteger counter = new AtomicInteger();
+		ImagePlus image = countingImagePlus(counter);
+		Img<? extends RealType<?>> img = VirtualStackAdapter.wrapByte(image);
+		runFlatIteration(img);
+		assertTrue(counter.get() < 120); // don't call getProcessor too often
+	}
+
+	@Test
+	public void testIteratePermutedVirtualStack() {
+		AtomicInteger counter = new AtomicInteger();
+		ImagePlus image = countingImagePlus(counter);
+		Img<? extends RealType<?>> img = VirtualStackAdapter.wrapByte(image);
+		runFlatIteration(Views.permute(img, 0, 2));
+		assertTrue(counter.get() < 120); // don't call getProcessor too often
+	}
+
+	@Test
+	public void testIterateImagePlusAdapter() {
+		AtomicInteger counter = new AtomicInteger();
+		ImagePlus image = countingImagePlus(counter);
+		Img<? extends RealType<?>> img = ImagePlusAdapter.wrapByte(image);
+		runFlatIteration(Views.permute(img, 0, 2));
+		assertTrue(counter.get() < 120); // don't call getProcessor too often
+	}
+
+	private ImagePlus countingImagePlus(AtomicInteger counter) {
+		// NB: create an ImagePlus that counts how many ImageProcessors are accessed
+		VirtualStack stack = new VirtualStack(100, 100, 100) {
+			@Override public ImageProcessor getProcessor( int n )
+			{
+				counter.incrementAndGet();
+				return new ByteProcessor( getWidth(), getHeight() );
+			}
+		};
+		return new ImagePlus("title", stack);
+	}
+
+	private void runFlatIteration(RandomAccessibleInterval<? extends RealType<?>> imgPlus) {
+		for(RealType pixel : Views.flatIterable(imgPlus))
+			;
+	}
+
+}

--- a/src/test/java/net/imglib2/img/VirtualStackAdapterTest.java
+++ b/src/test/java/net/imglib2/img/VirtualStackAdapterTest.java
@@ -1,0 +1,121 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img;
+
+import ij.ImagePlus;
+import net.imglib2.img.display.imagej.ImageJFunctions;
+import net.imglib2.test.AssertImgs;
+import net.imglib2.test.RandomImgs;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.NumericType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.FloatType;
+import org.junit.Test;
+
+/**
+ * Tests {@link VirtualStackAdapter}.
+ *
+ * @author Matthias Arzt
+ */
+
+public class VirtualStackAdapterTest
+{
+
+	private static final long[] DIMENSIONS = { 2, 3, 4, 5, 6 };
+
+	// TODO fix test
+	@Test
+	public void testUnsignedByte()
+	{
+		ImagePlus image = randomImagePlus( new UnsignedByteType(), DIMENSIONS );
+		final Img< UnsignedByteType > actual = VirtualStackAdapter.wrapByte( image );
+		final Img< UnsignedByteType > expected = ImagePlusAdapter.wrapByte( image );
+		AssertImgs.assertImageEquals( expected, actual );
+	}
+
+	@Test
+	public void testUnsignedShort()
+	{
+		ImagePlus image = randomImagePlus( new UnsignedShortType(), DIMENSIONS );
+		final Img< UnsignedShortType > actual = VirtualStackAdapter.wrapShort( image );
+		final Img< UnsignedShortType > expected = ImagePlusAdapter.wrapShort( image );
+		AssertImgs.assertImageEquals( expected, actual );
+	}
+
+	@Test
+	public void testRGB()
+	{
+		ImagePlus image = randomImagePlus( new ARGBType(), DIMENSIONS );
+		final Img< ARGBType > actual = VirtualStackAdapter.wrapRGBA( image );
+		final Img< ARGBType > expected = ImagePlusAdapter.wrapRGBA( image );
+		AssertImgs.assertImageEquals( expected, actual );
+	}
+
+	@Test
+	public void testFloat()
+	{
+		ImagePlus image = randomImagePlus( new FloatType(), DIMENSIONS );
+		final Img< FloatType > actual = VirtualStackAdapter.wrapFloat( image );
+		final Img< FloatType > expected = ImagePlusAdapter.wrapFloat( image );
+		AssertImgs.assertImageEquals( expected, actual );
+	}
+
+	@Test
+	public void testLowerNumDimensions()
+	{
+		ImagePlus image = randomImagePlus( new UnsignedByteType(), 2, 3, 6 );
+		final Img< UnsignedByteType > actual = VirtualStackAdapter.wrapByte( image );
+		final Img< UnsignedByteType > expected = ImagePlusAdapter.wrapByte( image );
+		AssertImgs.assertImageEquals( expected, actual );
+	}
+
+	@Test
+	public void testSingletonDimensions()
+	{
+		ImagePlus image = randomImagePlus( new UnsignedByteType(), 2, 1, 1, 6 );
+		final Img< UnsignedByteType > actual = VirtualStackAdapter.wrapByte( image );
+		final Img< UnsignedByteType > expected = ImagePlusAdapter.wrapByte( image );
+		AssertImgs.assertImageEquals( expected, actual );
+	}
+
+	private < T extends NativeType< T > & NumericType< T > > ImagePlus randomImagePlus( T type, long... dimensions )
+	{
+		Img< T > random = RandomImgs.randomImage( type, dimensions );
+		return ImageJFunctions.wrap( random, "test" );
+	}
+
+}

--- a/src/test/java/net/imglib2/img/display/imagej/ArrayImgToVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/ArrayImgToVirtualStackTest.java
@@ -1,0 +1,93 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.display.imagej;
+
+import ij.ImagePlus;
+import net.imagej.ImgPlus;
+import net.imagej.axis.Axes;
+import net.imagej.axis.AxisType;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.cell.CellImg;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.real.FloatType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class ArrayImgToVirtualStackTest
+{
+	@Test
+	public void testSharedBuffer()
+	{
+		int width = 2;
+		int height = 3;
+		byte[] buffer = new byte[ width * height ];
+		ImgPlus< UnsignedByteType > img = new ImgPlus<>( ArrayImgs.unsignedBytes( buffer, width, height ) );
+		ImagePlus imagePlus = ArrayImgToVirtualStack.wrap( img );
+		assertEquals( width, imagePlus.getWidth() );
+		assertEquals( height, imagePlus.getHeight() );
+		assertSame( buffer, imagePlus.getProcessor().getPixels() );
+	}
+
+	@Test
+	public void testIsSupported()
+	{
+		ImgPlus< UnsignedByteType > supported = new ImgPlus<>( ArrayImgs.unsignedBytes( 2, 2 ), "image", new AxisType[] { Axes.X, Axes.Y } );
+		ImgPlus< UnsignedByteType > unsupported1 = new ImgPlus<>( ArrayImgs.unsignedBytes( 2, 2, 3 ), "image", new AxisType[] { Axes.X, Axes.Y, Axes.Z } );
+		CellImg< UnsignedByteType, ? > cellImg = new CellImgFactory< UnsignedByteType >().create( new long[] { 2, 2 }, new UnsignedByteType() );
+		ImgPlus< UnsignedByteType > unsupported2 = new ImgPlus<>( cellImg, "image", new AxisType[] { Axes.X, Axes.Y } );
+		assertTrue( ArrayImgToVirtualStack.isSupported( supported ) );
+		assertFalse( ArrayImgToVirtualStack.isSupported( unsupported1 ) );
+		assertFalse( ArrayImgToVirtualStack.isSupported( unsupported2 ) );
+	}
+
+	@Test
+	public void testPersistence() {
+		// setup
+		float expected = 42.0f;
+		Img<FloatType> img = ArrayImgs.floats(1, 1);
+		ImgPlus<FloatType> imgPlus = new ImgPlus<FloatType>(img, "title", new AxisType[]{ Axes.X, Axes.Y });
+		ImagePlus imagePlus = ArrayImgToVirtualStack.wrap(imgPlus);
+		// process
+		imagePlus.getProcessor().setf(0, 0, expected);
+		// test
+		assertEquals(expected, img.cursor().next().getRealFloat(), 0.0f);
+	}
+}

--- a/src/test/java/net/imglib2/img/display/imagej/ImageJVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/ImageJVirtualStackTest.java
@@ -1,0 +1,177 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.display.imagej;
+
+import ij.ImagePlus;
+import ij.ImageStack;
+import ij.VirtualStack;
+import ij.process.ByteProcessor;
+import ij.process.ColorProcessor;
+import ij.process.FloatProcessor;
+import ij.process.ImageProcessor;
+import ij.process.ShortProcessor;
+import net.imglib2.RandomAccess;
+import net.imglib2.converter.Converter;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.test.RandomImgs;
+import net.imglib2.type.Type;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ImageJVirtualStackTest
+{
+	@Test
+	public void testColorProcessor() {
+		// NB: ColorModel can cause troubles when using a ColorProcessor so try to create on
+		Img< ARGBType > img = ArrayImgs.argbs( 1, 1 );
+		ImageStack stackARGB = new ImageJVirtualStackARGB<>( img, ( i, o ) -> o.set( i.get() ) );
+		ImagePlus imagePlus = new ImagePlus( "title", stackARGB );
+		ImageStack stack = imagePlus.getStack();
+		assertTrue( stack.getProcessor( 1 ) instanceof ColorProcessor );
+	}
+
+	@Test
+	public void test()
+	{
+		Img< UnsignedByteType > img = RandomImgs.randomImage( new UnsignedByteType(), 1000, 1000, 10 );
+		VirtualStack vs = new ImageJVirtualStackUnsignedByte<>( img, copyConverter() );
+		RandomAccess< UnsignedByteType > randomAccess = img.randomAccess();
+		for ( int z = 0; z < 10; z++ )
+		{
+			ImageProcessor processor = vs.getProcessor( z + 1 );
+			for ( int y = 0; y < 1000; y++ )
+				for ( int x = 0; x < 1000; x++ )
+				{
+					randomAccess.setPosition( x, 0 );
+					randomAccess.setPosition( y, 1 );
+					randomAccess.setPosition( z, 2 );
+					assertEquals( randomAccess.get().get(), processor.get( x, y ) );
+				}
+		}
+	}
+
+	@Test
+	public void testGetProcessor()
+	{
+		VirtualStack vs = example();
+		assertEquals( 2, vs.getProcessor( 1 ).get( 1, 0 ) );
+		assertEquals( 6, vs.getProcessor( 2 ).get( 2, 0 ) );
+	}
+
+	private VirtualStack example()
+	{
+		Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( new byte[] { 1, 2, 3, 4, 5, 6 }, 3, 1, 2 );
+		return new ImageJVirtualStackUnsignedByte<>( img, copyConverter() );
+	}
+
+	@Test
+	public void testGetHeight()
+	{
+		VirtualStack vs = example();
+		assertEquals( 1, vs.getHeight() );
+	}
+
+	@Test
+	public void testGetWidth()
+	{
+		VirtualStack vs = example();
+		assertEquals( 3, vs.getWidth() );
+	}
+
+	@Test
+	public void testGetSize()
+	{
+		VirtualStack vs = example();
+		assertEquals( 2, vs.getSize() );
+	}
+
+	@Test
+	public void testBitDepth()
+	{
+		VirtualStack vs = example();
+		assertEquals( 8, vs.getBitDepth() );
+	}
+
+	@Test
+	public void testGetPixels() {
+		VirtualStack vs = example();
+		assertArrayEquals( new byte[] {4, 5, 6}, (byte[]) vs.getPixels( 2 ) );
+	}
+
+	@Test
+	public void testByteProcessor() {
+		VirtualStack vs = example();
+		assertTrue( vs.getProcessor( 1 ) instanceof ByteProcessor );
+	}
+
+	@Test
+	public void testFloatProcessor() {
+		float value = 42f;
+		VirtualStack vs = new ImageJVirtualStackFloat<>( ArrayImgs.floats( new float[]{ value }, 1, 1, 1 ), copyConverter() );
+		ImageProcessor processor = vs.getProcessor( 1 );
+		assertTrue( processor instanceof FloatProcessor );
+		assertEquals( value, processor.getf( 0, 0 ), 0f );
+	}
+
+	@Test
+	public void testShortProcessor() {
+		short value = 13;
+		VirtualStack vs = new ImageJVirtualStackUnsignedShort<>( ArrayImgs.unsignedShorts( new short[]{ value }, 1, 1, 1), copyConverter() );
+		ImageProcessor processor = vs.getProcessor( 1 );
+		assertTrue( processor instanceof ShortProcessor );
+		assertEquals( value, processor.get( 0, 0 ) );
+	}
+
+	@Test
+	public void testProcessor() {
+		int value = 43;
+		VirtualStack vs = new ImageJVirtualStackARGB<>( ArrayImgs.argbs( new int[]{ value }, 1, 1, 1 ), copyConverter() );
+		ImageProcessor processor = vs.getProcessor( 1 );
+		assertTrue( processor instanceof ColorProcessor );
+		assertEquals( value, processor.get( 0, 0 ) & 0x00ffffff );
+	}
+
+	private < T extends Type<T> > Converter< T, T > copyConverter()
+	{
+		return ( i, o ) -> o.set( i );
+	}
+
+}

--- a/src/test/java/net/imglib2/img/display/imagej/ImageJVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/ImageJVirtualStackTest.java
@@ -56,6 +56,8 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import static org.junit.Assert.assertNotSame;
+
 public class ImageJVirtualStackTest
 {
 	@Test
@@ -174,4 +176,14 @@ public class ImageJVirtualStackTest
 		return ( i, o ) -> o.set( i );
 	}
 
+	@Test
+	public void testProcessorPerPlane()
+	{
+		Img< UnsignedByteType > expected = RandomImgs.randomImage( new UnsignedByteType(), 100, 100, 100 );
+		ImagePlus imagePlus = ImageJFunctions.wrap( expected, "title");
+		ImageStack stack = imagePlus.getStack();
+		ImageProcessor p1 = stack.getProcessor( 1 );
+		ImageProcessor p2 = stack.getProcessor( 2 );
+		assertNotSame(p1, p2);
+	}
 }

--- a/src/test/java/net/imglib2/img/display/imagej/ImageJVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/ImageJVirtualStackTest.java
@@ -54,9 +54,8 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertTrue;
 
 public class ImageJVirtualStackTest
 {

--- a/src/test/java/net/imglib2/img/display/imagej/ImgLib2ToVirtualStackBenchmark.java
+++ b/src/test/java/net/imglib2/img/display/imagej/ImgLib2ToVirtualStackBenchmark.java
@@ -1,0 +1,132 @@
+/*-
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.display.imagej;
+
+import net.imagej.ImgPlus;
+import net.imagej.axis.Axes;
+import net.imagej.axis.AxisType;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.img.planar.PlanarImgs;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+@State( Scope.Benchmark )
+public class ImgLib2ToVirtualStackBenchmark
+{
+
+	long[] smallDims = { 10, 10, 10 };
+	long[] deepDims = { 10, 10, 1000000 };
+	long[] cubicDims = { 1000, 1000, 1000 };
+
+	private final ImgPlus< UnsignedByteType > smallCellImage = makeImgPlus( createCellImg( deepDims ) );
+	private final ImgPlus< UnsignedByteType > deepCellImage = makeImgPlus( createCellImg( deepDims ) );
+	private final ImgPlus< UnsignedByteType > cubicCellImage = makeImgPlus( createCellImg( cubicDims ) );
+	private final ImgPlus< UnsignedByteType > smallPlanarImg = makeImgPlus( PlanarImgs.unsignedBytes( smallDims ) );
+	private final ImgPlus< UnsignedByteType > cubicPlanarImg = makeImgPlus( PlanarImgs.unsignedBytes( cubicDims ) );
+	private final ImgPlus< UnsignedByteType > deepPlanarImg = makeImgPlus( PlanarImgs.unsignedBytes( deepDims ) );
+	private final ImgPlus< UnsignedByteType > small2dArrayImg = makeImgPlus( ArrayImgs.unsignedBytes( 10, 10 ) );
+	private final ImgPlus< UnsignedByteType > big2dArrayImg = makeImgPlus( ArrayImgs.unsignedBytes( 10000, 10000 ) );
+
+	@Benchmark
+	public void testSmallCellImg() {
+		ImgToVirtualStack.wrap( smallCellImage );
+	}
+
+	@Benchmark
+	public void testDeepCellImg() {
+		ImgToVirtualStack.wrap( deepCellImage );
+	}
+
+	@Benchmark
+	public void testCubicCellImg() {
+		ImgToVirtualStack.wrap( cubicCellImage );
+	}
+
+	@Benchmark
+	public void testSmallPlanarImg() {
+		PlanarImgToVirtualStack.wrap( smallPlanarImg );
+	}
+
+	@Benchmark
+	public void testCubicPlanarImg() {
+		PlanarImgToVirtualStack.wrap( cubicPlanarImg );
+	}
+
+	@Benchmark
+	public void testDeepPlanarImg() {
+		PlanarImgToVirtualStack.wrap( deepPlanarImg );
+	}
+
+	@Benchmark
+	public void testSmall2dArrayImg() {
+		ArrayImgToVirtualStack.wrap( small2dArrayImg );
+	}
+
+	@Benchmark
+	public void testLarge2dArrayImg() {
+		ArrayImgToVirtualStack.wrap( big2dArrayImg );
+	}
+
+	private ImgPlus< UnsignedByteType > makeImgPlus( Img< UnsignedByteType > deepPlanarImg )
+	{
+		AxisType[] axes = { Axes.X, Axes.Y, Axes.Z };
+		return new ImgPlus<>( deepPlanarImg, "title", axes );
+	}
+
+	private Img<UnsignedByteType> createCellImg(long... dim) {
+		return new CellImgFactory<>( new UnsignedByteType(  ) ).create( dim );
+	}
+
+	public static void main( final String... args ) throws RunnerException
+	{
+		final Options opt = new OptionsBuilder()
+				.include( ImgLib2ToVirtualStackBenchmark.class.getSimpleName() )
+				.forks( 0 )
+				.warmupIterations( 4 )
+				.measurementIterations( 8 )
+				.warmupTime( TimeValue.milliseconds( 100 ) )
+				.measurementTime( TimeValue.milliseconds( 100 ) )
+				.build();
+		new Runner( opt ).run();
+	}
+}

--- a/src/test/java/net/imglib2/img/display/imagej/ImgPlusViewsTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/ImgPlusViewsTest.java
@@ -1,8 +1,8 @@
-/*
+/*-
  * #%L
  * ImgLib2: a general-purpose, multidimensional image processing library.
  * %%
- * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
  * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
  * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
  * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
@@ -31,34 +31,29 @@
  * POSSIBILITY OF SUCH DAMAGE.
  * #L%
  */
-
 package net.imglib2.img.display.imagej;
 
-import java.util.concurrent.ExecutorService;
-
-import ij.ImagePlus;
 import net.imagej.ImgPlus;
-import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.converter.Converter;
-import net.imglib2.type.numeric.ARGBType;
+import net.imagej.axis.Axes;
+import net.imagej.axis.AxisType;
+import net.imglib2.img.array.ArrayImg;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import org.junit.Test;
 
-/**
- * TODO
- *
- */
-public class ImageJVirtualStackARGB< S > extends ImageJVirtualStack< S, ARGBType >
-{
-	public static ImageJVirtualStackARGB< ARGBType > wrap( RandomAccessibleInterval< ARGBType > source ) {
-		return new ImageJVirtualStackARGB<>( source, ( input, output ) -> output.set( input ) );
-	}
+import static org.junit.Assert.assertEquals;
 
-	public ImageJVirtualStackARGB( RandomAccessibleInterval< S > source, Converter< ? super S, ARGBType > converter)
-	{
-		this(source, converter, null);
-	}
-	public ImageJVirtualStackARGB( RandomAccessibleInterval< S > source, Converter< ? super S, ARGBType > converter, ExecutorService service )
-	{
-		super( source, converter, new ARGBType(), 24, service);
-		setMinAndMax( 0, 255 );
+public class ImgPlusViewsTest {
+
+	@Test
+	public void testHyperSlice() {
+		ArrayImg<UnsignedByteType, ByteArray> img = ArrayImgs.unsignedBytes(1, 1, 1, 1);
+		ImgPlus<UnsignedByteType> imgPlus = new ImgPlus<>(img, "image", new AxisType[]{Axes.X, Axes.Y, Axes.Z, Axes.TIME});
+		ImgPlus<UnsignedByteType> result = ImgPlusViews.hyperSlice(imgPlus, 2, 0);
+		assertEquals(3, result.numDimensions());
+		assertEquals(Axes.X, result.axis(0).type());
+		assertEquals(Axes.Y, result.axis(1).type());
+		assertEquals(Axes.TIME, result.axis(2).type());
 	}
 }

--- a/src/test/java/net/imglib2/img/display/imagej/ImgToVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/ImgToVirtualStackTest.java
@@ -1,0 +1,263 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.display.imagej;
+
+import ij.ImagePlus;
+import ij.process.ByteProcessor;
+import ij.process.FloatProcessor;
+import ij.process.ImageProcessor;
+import ij.process.ShortProcessor;
+import net.imagej.ImgPlus;
+import net.imagej.axis.Axes;
+import net.imagej.axis.AxisType;
+import net.imglib2.FinalInterval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.ImgView;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.logic.BoolType;
+import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.ByteType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.LongType;
+import net.imglib2.type.numeric.integer.ShortType;
+import net.imglib2.type.numeric.integer.Unsigned128BitType;
+import net.imglib2.type.numeric.integer.Unsigned12BitType;
+import net.imglib2.type.numeric.integer.Unsigned2BitType;
+import net.imglib2.type.numeric.integer.Unsigned4BitType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
+import net.imglib2.type.numeric.integer.UnsignedLongType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.ConstantUtils;
+import net.imglib2.view.Views;
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class ImgToVirtualStackTest
+{
+	@Test
+	public void testAxisOrder() {
+		Img< UnsignedByteType> img = ArrayImgs.unsignedBytes( 1, 1, 2, 3, 4 );
+		fill( img );
+		ImgPlus< UnsignedByteType > imgPlus = new ImgPlus<>( img, "title", new AxisType[] { Axes.X, Axes.Y, Axes.TIME, Axes.CHANNEL, Axes.Z } );
+		ImagePlus imagePlus = ImgToVirtualStack.wrap( imgPlus, false );
+		assertEquals( 2, imagePlus.getStack().getProcessor( imagePlus.getStackIndex( 1, 1, 2 ) ).get( 0, 0 ) );
+		assertEquals( 7, imagePlus.getStack().getProcessor( imagePlus.getStackIndex( 1, 2, 1 ) ).get( 0, 0 ) );
+		assertEquals( 3, imagePlus.getStack().getProcessor( imagePlus.getStackIndex( 2, 1, 1 ) ).get( 0, 0 ) );
+	}
+
+	@Test
+	public void test1DStack() {
+		Img< UnsignedByteType> img = ArrayImgs.unsignedBytes( 2, 2 );
+		fill( img );
+		ImgPlus< UnsignedByteType > imgPlus = new ImgPlus<>( img, "title", new AxisType[] { Axes.TIME, Axes.X } );
+		ImagePlus imagePlus = ImgToVirtualStack.wrap( imgPlus, false );
+		assertArrayEquals( new byte[]{ 1, 3 }, (byte[]) imagePlus.getStack().getPixels( imagePlus.getStackIndex( 1, 1, 1 ) ) );
+		assertArrayEquals( new byte[]{ 2, 4 }, (byte[]) imagePlus.getStack().getPixels( imagePlus.getStackIndex( 1, 1, 2 ) ) );
+	}
+
+	@Test
+	public void testNoXY() {
+		Img< UnsignedByteType> img = ArrayImgs.unsignedBytes( 2, 2 );
+		fill( img );
+		ImgPlus< UnsignedByteType > imgPlus = new ImgPlus<>( img, "title", new AxisType[] { Axes.TIME, Axes.CHANNEL } );
+		ImagePlus imagePlus = ImgToVirtualStack.wrap( imgPlus, false );
+		assertArrayEquals( new byte[]{ 2 }, (byte[]) imagePlus.getStack().getPixels( imagePlus.getStackIndex( 1, 1, 2 ) ) );
+		assertArrayEquals( new byte[]{ 3 }, (byte[]) imagePlus.getStack().getPixels( imagePlus.getStackIndex( 2, 1, 1 ) ) );
+	}
+
+	@Ignore("not supporting more the five dimensions yet")
+	@Test
+	public void test6d() {
+		Img< UnsignedByteType> img = ArrayImgs.unsignedBytes( 2, 2, 2, 2, 2, 2 );
+		fill( img );
+		ImgPlus< UnsignedByteType > imgPlus = new ImgPlus<>( img, "title", new AxisType[] { Axes.X, Axes.Y, Axes.Z, Axes.CHANNEL, Axes.TIME, Axes.CHANNEL } );
+		ImagePlus imagePlus = ImgToVirtualStack.wrap( imgPlus, true );
+		assertArrayEquals( new byte[]{ 2 }, (byte[]) imagePlus.getStack().getPixels( imagePlus.getStackIndex( 1, 1, 2 ) ) );
+		assertArrayEquals( new byte[]{ 3 }, (byte[]) imagePlus.getStack().getPixels( imagePlus.getStackIndex( 2, 1, 1 ) ) );
+	}
+
+	@Test
+	public void testColoredAxisOrder() {
+		Img< UnsignedByteType> img = ArrayImgs.unsignedBytes( 1, 1, 2, 3, 4 );
+		fill( img );
+		ImgPlus< UnsignedByteType > imgPlus = new ImgPlus<>( img, "title", new AxisType[] { Axes.X, Axes.Y, Axes.TIME, Axes.CHANNEL, Axes.Z } );
+		ImagePlus imagePlus = ImgToVirtualStack.wrap( imgPlus, true );
+		assertEquals( 0xff020406, imagePlus.getStack().getProcessor( imagePlus.getStackIndex( 1, 1, 2 ) ).get( 0, 0 ) );
+		assertEquals( 0xff07090b, imagePlus.getStack().getProcessor( imagePlus.getStackIndex( 1, 2, 1 ) ).get( 0, 0 ) );
+	}
+
+	@Test
+	public void testBitType() {
+		testTypeConversion(ByteProcessor.class, 1, new BitType(true));
+	}
+
+	@Test
+	public void testBoolType() {
+		testTypeConversion(ByteProcessor.class, 1, new BoolType(true));
+	}
+
+	@Test
+	public void testUnsigned2BitType() {
+		testTypeConversion(ByteProcessor.class, 3, new Unsigned2BitType(3));
+	}
+
+	@Test
+	public void testUnsigned4BitTypeType() {
+		testTypeConversion(ByteProcessor.class, 15, new Unsigned4BitType(15));
+	}
+
+	@Test
+	public void testUnsignedByteType() {
+		testTypeConversion(ByteProcessor.class, 42f, new UnsignedByteType(42));
+	}
+
+	@Test
+	public void testUnsigned12BitType() {
+		testTypeConversion(ShortProcessor.class, 420, new Unsigned12BitType(420));
+	}
+
+	@Test
+	public void testUnsignedShortType() {
+		testTypeConversion(ShortProcessor.class, 42f, new UnsignedShortType(42));
+	}
+
+	@Test
+	public void testUnsignedIntType() {
+		testTypeConversion(FloatProcessor.class, 42, new UnsignedIntType(42));
+	}
+
+	@Test
+	public void testUnsignedLongType() {
+		testTypeConversion(FloatProcessor.class, 42, new UnsignedLongType(42));
+	}
+
+	@Test
+	public void testUnsigned128BitType() {
+		testTypeConversion(FloatProcessor.class, 1000000, new Unsigned128BitType(1000000, 0));
+	}
+
+	@Test
+	public void testByteType() {
+		testTypeConversion(FloatProcessor.class, -42, new ByteType((byte) -42));
+	}
+
+	@Test
+	public void testShortType() {
+		testTypeConversion(FloatProcessor.class, -42, new ShortType((short) -42));
+	}
+
+	@Test
+	public void testIntType() {
+		testTypeConversion(FloatProcessor.class, -42, new IntType(-42));
+	}
+
+	@Test
+	public void testLongType() {
+		testTypeConversion(FloatProcessor.class, -42, new LongType(-42));
+	}
+
+	@Test
+	public void testFloatType() {
+		testTypeConversion(FloatProcessor.class, -42f, new FloatType(-42));
+	}
+
+	@Test
+	public void testDoubleType() {
+		testTypeConversion(FloatProcessor.class, -42f, new DoubleType(-42));
+	}
+
+	private <T extends RealType<T>> void testTypeConversion(Class<? extends ImageProcessor> processorClass, float expected, T input) {
+		RandomAccessibleInterval<T> rai = ConstantUtils.constantRandomAccessibleInterval(input, 2, new FinalInterval(1, 1));
+		Img<T> image = ImgView.wrap(rai, null);
+		ImgPlus<T> imgPlus = new ImgPlus<T>(image, "title", new AxisType[]{Axes.X, Axes.Y});
+		// process
+		ImagePlus imagePlus = ImgToVirtualStack.wrap(imgPlus, false);
+		// test
+		ImageProcessor processor = imagePlus.getProcessor();
+		Assert.assertTrue(processorClass.isInstance(processor));
+		Assert.assertEquals(expected, processor.getPixelValue(0, 0), 0f);
+	}
+
+	private void fill( RandomAccessibleInterval< ? extends IntegerType > img )
+	{
+		AtomicInteger i = new AtomicInteger();
+		Views.flatIterable( img ).forEach( pixel -> pixel.setInteger( i.incrementAndGet() ) );
+	}
+
+	@Ignore("not working yet")
+	@Test
+	public void testUnknownAxes() {
+		byte[] array = {1, 2, 3, 4, 5, 6};
+		Img<UnsignedByteType> img = ArrayImgs.unsignedBytes(array, 1, 1, 2, 3);
+		AxisType[] axes = { Axes.unknown(), Axes.unknown(), Axes.TIME, Axes.unknown() };
+		ImagePlus result = ImgToVirtualStack.wrap(new ImgPlus<>(img, "title", axes), false);
+		assertEquals(3, result.getNChannels());
+		assertEquals(2, result.getNFrames());
+	}
+
+	@Test
+	public void testPersistence() {
+		// setup
+		Img<FloatType> img = ArrayImgs.floats(1, 1);
+		ImgPlus<FloatType> imgPlus = new ImgPlus<FloatType>(img, "title", new AxisType[]{ Axes.X, Axes.Y });
+		ImagePlus imagePlus = ImgToVirtualStack.wrap(imgPlus, false);
+		float expected = 42;
+		// process
+		ImageProcessor processor = imagePlus.getStack().getProcessor(1);
+		processor.setf(0, 0, expected);
+		imagePlus.getStack().setPixels(processor.getPixels(), 1); // NB: required to signal data changed
+		// test
+		assertEquals(expected, img.cursor().next().get(), 0.0f);
+	}
+}

--- a/src/test/java/net/imglib2/img/display/imagej/ImgToVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/ImgToVirtualStackTest.java
@@ -116,7 +116,7 @@ public class ImgToVirtualStackTest
 		assertArrayEquals( new byte[]{ 3 }, (byte[]) imagePlus.getStack().getPixels( imagePlus.getStackIndex( 2, 1, 1 ) ) );
 	}
 
-	@Ignore("not supporting more the five dimensions yet")
+	@Ignore("not supporting more than five dimensions yet")
 	@Test
 	public void test6d() {
 		Img< UnsignedByteType> img = ArrayImgs.unsignedBytes( 2, 2, 2, 2, 2, 2 );
@@ -235,7 +235,6 @@ public class ImgToVirtualStackTest
 		Views.flatIterable( img ).forEach( pixel -> pixel.setInteger( i.incrementAndGet() ) );
 	}
 
-	@Ignore("not working yet")
 	@Test
 	public void testUnknownAxes() {
 		byte[] array = {1, 2, 3, 4, 5, 6};

--- a/src/test/java/net/imglib2/img/display/imagej/ImgToVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/ImgToVirtualStackTest.java
@@ -71,12 +71,7 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Predicate;
-import java.util.function.Supplier;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertArrayEquals;
@@ -258,5 +253,19 @@ public class ImgToVirtualStackTest
 		imagePlus.getStack().setPixels(processor.getPixels(), 1); // NB: required to signal data changed
 		// test
 		assertEquals(expected, img.cursor().next().get(), 0.0f);
+	}
+
+	@Test
+	public void testPersistenceBits() {
+		// setup
+		Img<BitType> img = ArrayImgs.bits(1, 1);
+		ImgPlus<BitType> imgPlus = new ImgPlus<BitType>(img, "title", new AxisType[]{ Axes.X, Axes.Y });
+		ImagePlus imagePlus = ImgToVirtualStack.wrapAndScaleBitType(imgPlus);
+		// process
+		ImageProcessor processor = imagePlus.getStack().getProcessor(1);
+		processor.setf(0, 0, 255);
+		imagePlus.getStack().setPixels(processor.getPixels(), 1); // NB: required to signal data changed
+		// test
+		assertEquals(true, img.cursor().next().get());
 	}
 }

--- a/src/test/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStackTest.java
@@ -1,0 +1,129 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.display.imagej;
+
+import ij.ImagePlus;
+import ij.VirtualStack;
+import net.imagej.ImgPlus;
+import net.imagej.axis.Axes;
+import net.imagej.axis.AxisType;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.planar.PlanarImg;
+import net.imglib2.img.planar.PlanarImgFactory;
+import net.imglib2.img.planar.PlanarImgs;
+import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.view.Views;
+import org.junit.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertSame;
+
+public class PlanarImgToVirtualStackTest
+{
+	@Test
+	public void testStorageArray() {
+		PlanarImg< UnsignedByteType, ? > img = example();
+		VirtualStack stack = PlanarImgToVirtualStack.wrap( img );
+		assertSame( img.getPlane( 1 ).getCurrentStorageArray(), stack.getPixels( 2 ) );
+	}
+
+	@Test
+	public void testPixelValues() {
+		PlanarImg< UnsignedByteType, ? > img = example();
+		VirtualStack stack = PlanarImgToVirtualStack.wrap( img );
+		assertArrayEquals( new byte[]{ 1, 2, 3 }, (byte[]) stack.getPixels( 1 ));
+		assertArrayEquals( new byte[]{ 4, 5, 6 }, (byte[]) stack.getPixels( 2 ));
+	}
+
+	@Test
+	public void testImgPlus() {
+		// setup
+		PlanarImg< UnsignedByteType, ? > img = example();
+		String title = "test image";
+		ImgPlus< UnsignedByteType > imgPlus = new ImgPlus<>( img, title, new AxisType[] { Axes.X, Axes.Y, Axes.TIME } );
+		// process
+		ImagePlus imagePlus = PlanarImgToVirtualStack.wrap( imgPlus );
+		// test
+		assertEquals( title, imagePlus.getTitle() );
+		assertEquals( 3, imagePlus.getWidth() );
+		assertEquals( 1, imagePlus.getHeight() );
+		assertEquals( 1, imagePlus.getNChannels() );
+		assertEquals( 1, imagePlus.getNSlices() );
+		assertEquals( 2, imagePlus.getNFrames() );
+	}
+
+	@Test
+	public void testAxisOrder() {
+		PlanarImg< UnsignedByteType, ? > img = new PlanarImgFactory< UnsignedByteType >().create( new long[] { 1, 1, 2, 3, 4 }, new UnsignedByteType() );
+		fill( img );
+		ImgPlus< UnsignedByteType > imgPlus = new ImgPlus<>( img, "title", new AxisType[] { Axes.X, Axes.Y, Axes.TIME, Axes.CHANNEL, Axes.Z } );
+		ImagePlus imagePlus = PlanarImgToVirtualStack.wrap( imgPlus );
+		assertEquals( 2, imagePlus.getStack().getProcessor( imagePlus.getStackIndex( 1, 1, 2 ) ).get( 0, 0 ) );
+		assertEquals( 7, imagePlus.getStack().getProcessor( imagePlus.getStackIndex( 1, 2, 1 ) ).get( 0, 0 ) );
+		assertEquals( 3, imagePlus.getStack().getProcessor( imagePlus.getStackIndex( 2, 1, 1 ) ).get( 0, 0 ) );
+	}
+
+	private void fill( RandomAccessibleInterval< ? extends IntegerType > img )
+	{
+		AtomicInteger i = new AtomicInteger();
+		Views.flatIterable( img ).forEach( pixel -> pixel.setInteger( i.incrementAndGet() ) );
+	}
+
+	private PlanarImg< UnsignedByteType, ? > example()
+	{
+		PlanarImg< UnsignedByteType, ? > img = new PlanarImgFactory< UnsignedByteType >().create( new long[] { 3, 1, 2 }, new UnsignedByteType() );
+		fill( img );
+		return img;
+	}
+
+	@Test
+	public void testPersistence() {
+		// setup
+		PlanarImg<FloatType, FloatArray> img = PlanarImgs.floats(1, 1);
+		ImgPlus<FloatType> imgPlus = new ImgPlus<FloatType>(img, "title", new AxisType[]{ Axes.X, Axes.Y });
+		ImagePlus imagePlus = PlanarImgToVirtualStack.wrap(imgPlus);
+		float expected = 42.0f;
+		// process
+		imagePlus.getProcessor().setf(0, 0, expected);
+		// test
+		assertEquals(expected, img.cursor().next().get(), 0.0f);
+	}
+}

--- a/src/test/java/net/imglib2/test/AssertImgs.java
+++ b/src/test/java/net/imglib2/test/AssertImgs.java
@@ -1,0 +1,92 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.test;
+
+import net.imglib2.Interval;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.operators.ValueEquals;
+import net.imglib2.util.Intervals;
+import net.imglib2.view.Views;
+import org.junit.Assert;
+
+import java.util.Arrays;
+import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
+
+import static org.junit.Assert.fail;
+
+public class AssertImgs
+{
+	// TODO generalize & move to imglib2
+	public static < T > void assertImageEquals(
+			RandomAccessibleInterval< ? extends ValueEquals< T > > expected,
+			RandomAccessibleInterval< T > actual )
+	{
+		pairedForEach( expected, actual, ValueEquals::valueEquals );
+	}
+
+	public static void assertRealTypeImageEquals(
+			RandomAccessibleInterval< ? extends RealType< ? > > expected,
+			RandomAccessibleInterval< ? extends RealType< ? > > actual )
+	{
+		assertImageEquals( expected, actual, ( e, a ) -> e.getRealDouble() == a.getRealDouble() );
+	}
+
+	public static < T, U > void assertImageEquals(
+			RandomAccessibleInterval< T > expected, RandomAccessibleInterval< U > actual, BiPredicate< ? super T, ? super U > equals )
+	{
+		pairedForEach( expected, actual, ( e, a ) -> Assert.assertTrue( equals.test( e, a ) ) );
+	}
+
+	private static void assertIntervalEquals( Interval expected, Interval actual )
+	{
+		if ( !Intervals.equals( expected, actual ) )
+			fail( "intervals differ, expected=" + toString( expected ) + " actual=" + toString( actual ) );
+	}
+
+	private static String toString( Interval actual )
+	{
+		return "{min=" + Arrays.toString( Intervals.minAsLongArray( actual ) )
+				+ ",size=" + Arrays.toString( Intervals.dimensionsAsLongArray( actual ) ) + "}";
+	}
+
+	private static < A, B > void pairedForEach( RandomAccessibleInterval< A > expected, RandomAccessibleInterval< B > actual, BiConsumer< A, B > pairConsumer )
+	{
+		assertIntervalEquals( expected, actual );
+		Views.interval( Views.pair( expected, actual ), expected ).forEach( p -> pairConsumer.accept( p.getA(), p.getB() ) );
+	}
+
+}

--- a/src/test/java/net/imglib2/test/RandomImgs.java
+++ b/src/test/java/net/imglib2/test/RandomImgs.java
@@ -1,0 +1,87 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.test;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.util.Util;
+import net.imglib2.view.Views;
+
+import java.util.Random;
+import java.util.function.Consumer;
+
+public class RandomImgs
+{
+	// TODO generalize & move to imglib2
+	public static < T extends NativeType< T > > Img< T > randomImage( T type, long... dims )
+	{
+		Img< T > expected = new ArrayImgFactory< T >().create( dims, type );
+		return setRandomValues( expected );
+	}
+
+	private static < I extends RandomAccessibleInterval< T >, T extends NativeType< T > >
+	I setRandomValues( I image )
+	{
+		T type = Util.getTypeFromInterval( image );
+		Views.iterable( image ).forEach( randomSetter( type ) );
+		return image;
+	}
+
+	private static < T extends NativeType< T > > Consumer< T > randomSetter( T type )
+	{
+		Random random = new Random();
+		if ( type instanceof UnsignedByteType )
+			return b -> ( ( UnsignedByteType ) b ).setInteger( random.nextInt( ( 2 << 8 ) - 1 ) );
+		if ( type instanceof UnsignedShortType )
+			return b -> ( ( UnsignedShortType ) b ).setInteger( random.nextInt( ( 2 << 16 ) - 1 ) );
+		if ( type instanceof IntType )
+			return b -> ( ( IntType ) b ).setInteger( random.nextInt() );
+		if ( type instanceof ARGBType )
+			return b -> ( ( ARGBType ) b ).set( random.nextInt() );
+		if ( type instanceof FloatType )
+			return b -> ( ( FloatType ) b ).setReal( random.nextFloat() );
+		if ( type instanceof DoubleType )
+			return b -> ( ( DoubleType ) b ).setReal( random.nextDouble() );
+		throw new UnsupportedOperationException();
+	}
+}


### PR DESCRIPTION
This PR is required to improve the IJ1-IJ2 compatibility layer. It adds wrappers to translate between ImagePlus and ImgPlus. These new wrappers are faster than the existing ones. This is achieved by sharing buffers instead of copying and being lazily.

Add VirtualStackAdapter: 
* It's similar to ImagePlusAdapter as it presents an IJ1 ImagePlus as an IJ2 PlanarImg, but it's way faster during initializing when used for an ImagePlus that contains a VirtualStacks.

Refactor ImageJVirtualStack: 
* Code quality improvements.
* Fixing a bug when multiple ImageProcessors are used simultaneously.
* Adding ImgToVirtualStack#wrap method which simply takes an Img(Plus) and returns an ImagePlus.

Add PlanarImgToVirtualStack:
* Similar to ImageJVirtualStack but not as flexible. It shares buffers between the PlanarImg and ImagePlus instead of copying the planes.

Add ArrayImgToVirtualStack
* Similar to PlanarImgToVirtualStack, but works for 2d ArrayImg.