### PR TITLE
Implement "duplicate" for VirtualStack wrappers (Fixes #17)

### DIFF
--- a/src/main/java/net/imglib2/img/display/imagej/AbstractVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/AbstractVirtualStack.java
@@ -358,6 +358,6 @@ public abstract class AbstractVirtualStack extends VirtualStack
 	@Override
 	public ImageStack convertToFloat()
 	{
-		throw new UnsupportedOperationException();
+		return ImageStackUtils.convertToFloat( this );
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/AbstractVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/AbstractVirtualStack.java
@@ -42,6 +42,11 @@ import ij.ImageStack;
 import ij.VirtualStack;
 import ij.process.ImageProcessor;
 
+/**
+ * Abstract class to simplify the implementation of an {@link VirtualStack}.
+ *
+ * @author Matthias Arzt
+ */
 public abstract class AbstractVirtualStack extends VirtualStack
 {
 	private final int width;
@@ -341,13 +346,13 @@ public abstract class AbstractVirtualStack extends VirtualStack
 	@Override
 	public ImageStack duplicate()
 	{
-		throw new UnsupportedOperationException();
+		return ImageStackUtils.duplicate( this );
 	}
 
 	@Override
 	public ImageStack crop( final int x, final int y, final int z, final int width, final int height, final int depth )
 	{
-		throw new UnsupportedOperationException();
+		return ImageStackUtils.crop( this, x, y, z, width, height, depth );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/display/imagej/ImageStackUtils.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageStackUtils.java
@@ -72,4 +72,17 @@ class ImageStackUtils
 		}
 		return result;
 	}
+
+	/**
+	 * Create a new {@link ImageStack} with same content but featuring {@link ij.process.FloatProcessor}s.
+	 */
+	public static ImageStack convertToFloat( ImageStack stack )
+	{
+		ImageStack result = new ImageStack(stack.getWidth(), stack.getHeight(), stack.getColorModel());
+		for (int i=1; i<= stack.getSize(); i++) {
+			ImageProcessor ip = stack.getProcessor(i);
+			result.addSlice(stack.getSliceLabel(i), ip.convertToFloat() );
+		}
+		return result;
+	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageStackUtils.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageStackUtils.java
@@ -1,0 +1,75 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.display.imagej;
+
+import ij.ImageStack;
+import ij.process.ImageProcessor;
+
+/**
+ * Utility functions for the implementation of {@link AbstractVirtualStack}.
+ *
+ * @author Matthias Arzt
+ */
+class ImageStackUtils
+{
+	private ImageStackUtils()
+	{
+		// prevent from instantiation
+	}
+
+	/**
+	 * Creates a copy of a given {@link ImageStack}.
+	 */
+	public static ImageStack duplicate( ImageStack original )
+	{
+		return crop( original, 0, 0, 0, original.getWidth(), original.getHeight(), original.getSize() );
+	}
+
+	/**
+	 * Creates a new {@link ImageStack} by cropping the given stack
+	 */
+	public static ImageStack crop( ImageStack stack, int x, int y, int z, int width, int height, int depth )
+	{
+		if ( x < 0 || y < 0 || z < 0 || x + width > stack.getWidth() || y + height > stack.getHeight() || z + depth > stack.getSize() )
+			throw new IllegalArgumentException( "Argument out of range" );
+		ImageStack result = new ImageStack( width, height, stack.getColorModel() );
+		for ( int i = z; i < z + depth; i++ )
+		{
+			ImageProcessor ip = stack.getProcessor( i + 1 );
+			ip.setRoi( x, y, width, height );
+			result.addSlice( stack.getSliceLabel( i + 1 ), ip.crop() );
+		}
+		return result;
+	}
+}

--- a/src/test/java/net/imglib2/img/display/imagej/AbstractVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/AbstractVirtualStackTest.java
@@ -47,6 +47,22 @@ public class AbstractVirtualStackTest
 		assertArrayEquals( new byte[] { 6 }, ( byte[] ) duplicate.getPixels( 2 ) );
 	}
 
+	@Test
+	public void testConvetToFloat()
+	{
+		// setup
+		final ImageStack original = new TestVirtualStack( 1, 1, 2, new byte[][] { { 4 }, { 2 } } );
+		// process
+		final ImageStack result = original.convertToFloat();
+		// test
+		assertEquals( ImageStack.class, result.getClass() );
+		assertEquals( 1, result.getWidth() );
+		assertEquals( 1, result.getHeight() );
+		assertEquals( 2, result.getSize() );
+		assertArrayEquals( new float[] { 4 }, ( float[] ) result.getPixels( 1 ), 0 );
+		assertArrayEquals( new float[] { 2 }, ( float[] ) result.getPixels( 2 ), 0 );
+	}
+
 	private static class TestVirtualStack extends AbstractVirtualStack
 	{
 

--- a/src/test/java/net/imglib2/img/display/imagej/AbstractVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/AbstractVirtualStackTest.java
@@ -1,0 +1,66 @@
+package net.imglib2.img.display.imagej;
+
+import ij.ImageStack;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests {@link AbstractVirtualStack}
+ *
+ * @author Matthias Arzt
+ */
+public class AbstractVirtualStackTest
+{
+	@Test
+	public void testDuplicate()
+	{
+		// setup
+		byte[][] pixels = { { 4 }, { 2 } };
+		final ImageStack original = new TestVirtualStack( 1, 1, 2, pixels );
+		// process
+		final ImageStack duplicate = original.duplicate();
+		// test
+		assertEquals( ImageStack.class, duplicate.getClass() );
+		assertEquals( 1, duplicate.getWidth() );
+		assertEquals( 1, duplicate.getHeight() );
+		assertEquals( 2, duplicate.getSize() );
+		assertArrayEquals( pixels[ 0 ], ( byte[] ) duplicate.getPixels( 1 ) );
+		assertArrayEquals( pixels[ 1 ], ( byte[] ) duplicate.getPixels( 2 ) );
+	}
+
+	@Test
+	public void testCrop()
+	{
+		// setup
+		byte[][] pixels = new byte[][] { { 1, 2 }, { 3, 4 }, { 5, 6 } };
+		final ImageStack original = new TestVirtualStack( 1, 2, 3, pixels );
+		// process
+		final ImageStack duplicate = original.crop( 0, 1, 1, 1, 1, 2 );
+		// test
+		assertEquals( ImageStack.class, duplicate.getClass() );
+		assertEquals( 1, duplicate.getWidth() );
+		assertEquals( 1, duplicate.getHeight() );
+		assertEquals( 2, duplicate.getSize() );
+		assertArrayEquals( new byte[] { 4 }, ( byte[] ) duplicate.getPixels( 1 ) );
+		assertArrayEquals( new byte[] { 6 }, ( byte[] ) duplicate.getPixels( 2 ) );
+	}
+
+	private static class TestVirtualStack extends AbstractVirtualStack
+	{
+
+		private final byte[][] pixels;
+
+		public TestVirtualStack( int width, int height, int size, byte[][] pixels )
+		{
+			super( width, height, size, 8 );
+			this.pixels = pixels;
+		}
+
+		@Override public Object getPixels( int n )
+		{
+			return pixels[ n - 1 ];
+		}
+	}
+}


### PR DESCRIPTION
The PR implements the urgently required method "duplicate" for the imglib2 to VirtualStack wrappers.
See #17