### PR TITLE
Fix cropping for wrapped images

### DIFF
--- a/src/main/java/net/imglib2/img/display/imagej/AbstractVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/AbstractVirtualStack.java
@@ -53,7 +53,9 @@ public abstract class AbstractVirtualStack extends VirtualStack
 
 	private final int height;
 
-	private final int size;
+	private int size;
+
+	private int offset;
 
 	private final int bitDepth;
 
@@ -68,6 +70,7 @@ public abstract class AbstractVirtualStack extends VirtualStack
 		super( 10, 10, null, "" );
 		this.width = width;
 		this.height = height;
+		this.offset = 0;
 		this.size = size;
 		this.bitDepth = bitDepth;
 		this.colorModel = null;
@@ -81,7 +84,25 @@ public abstract class AbstractVirtualStack extends VirtualStack
 	}
 
 	@Override
-	public abstract Object getPixels( int n );
+	public final Object getPixels( int n )
+	{
+		return getPixelsZeroBasedIndex( toZeroBasedIndex( n ) );
+	}
+
+	@Override
+	public final void setPixels( final Object pixels, final int n )
+	{
+		setPixelsZeroBasedIndex( toZeroBasedIndex( n ), pixels );
+	}
+
+	private int toZeroBasedIndex( int n )
+	{
+		return ( n - 1 ) + offset;
+	}
+
+	protected abstract Object getPixelsZeroBasedIndex( int index );
+
+	protected abstract void setPixelsZeroBasedIndex( int index, Object pixels );
 
 	@Override
 	public ImageProcessor getProcessor( final int n )
@@ -120,19 +141,24 @@ public abstract class AbstractVirtualStack extends VirtualStack
 	@Override
 	public void deleteSlice( final int n )
 	{
-		// ignore
+		if ( n == 1 )
+			deleteFirstSlice();
+		else if ( n == size )
+			deleteLastSlice();
+		else
+			throw new UnsupportedOperationException( "AbstractVirtualStack only supports to delete first or last slice." );
+	}
+
+	private void deleteFirstSlice()
+	{
+		size--;
+		offset++;
 	}
 
 	@Override
 	public void deleteLastSlice()
 	{
-		// ignore
-	}
-
-	@Override
-	public void setPixels( final Object pixels, final int n )
-	{
-		// ignore for now
+		size--;
 	}
 
 	/**
@@ -153,7 +179,7 @@ public abstract class AbstractVirtualStack extends VirtualStack
 	@Override
 	public String getSliceLabel( final int n )
 	{
-		return Integer.toString( n );
+		return Integer.toString( toZeroBasedIndex( n ) + 1 );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
@@ -130,7 +130,7 @@ public class ImageJVirtualStack< S, T extends NativeType< T > > extends Abstract
 		return isWritable;
 	}
 
-	private ArrayImg< T, ? > getSlice( final int n )
+	private ArrayImg< T, ? > getSlice( final int index )
 	{
 		final int sizeX = ( int ) source.dimension( 0 );
 		final int sizeY = ( int ) source.dimension( 1 );
@@ -141,7 +141,7 @@ public class ImageJVirtualStack< S, T extends NativeType< T > > extends Abstract
 		if ( higherSourceDimensions.length > 0 )
 		{
 			final int[] position = new int[ higherSourceDimensions.length ];
-			IntervalIndexer.indexToPosition( n - 1, higherSourceDimensions, position );
+			IntervalIndexer.indexToPosition( index, higherSourceDimensions, position );
 			for ( int i = 0; i < position.length; i++ )
 				projector.setPosition( position[ i ], i + 2 );
 		}
@@ -150,14 +150,14 @@ public class ImageJVirtualStack< S, T extends NativeType< T > > extends Abstract
 	}
 
 	@Override
-	public Object getPixels( final int n )
+	protected Object getPixelsZeroBasedIndex( final int index )
 	{
-		final ArrayImg< T, ? > img = getSlice( n );
+		final ArrayImg< T, ? > img = getSlice( index );
 		return ( ( ArrayDataAccess< ? > ) img.update( null ) ).getCurrentStorageArray();
 	}
 
 	@Override
-	public void setPixels( final Object pixels, final int n )
+	protected void setPixelsZeroBasedIndex( final int index, final Object pixels )
 	{
 		if ( isWritable() )
 		{
@@ -171,7 +171,7 @@ public class ImageJVirtualStack< S, T extends NativeType< T > > extends Abstract
 			if ( higherSourceDimensions.length > 0 )
 			{
 				final int[] position = new int[ higherSourceDimensions.length ];
-				IntervalIndexer.indexToPosition( n - 1, higherSourceDimensions, position );
+				IntervalIndexer.indexToPosition( index, higherSourceDimensions, position );
 				for ( int i = 0; i < position.length; i++ )
 					origin = Views.hyperSlice( origin, 2, position[ i ] );
 			}

--- a/src/main/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStack.java
@@ -160,7 +160,25 @@ public class PlanarImgToVirtualStack extends AbstractVirtualStack
 	@Override
 	protected void setPixelsZeroBasedIndex( int index, Object pixels )
 	{
-		// ignore
+		setPlaneCastType( img, indexer.applyAsInt( index ), wrapPixelsToAccess( pixels ) );
+	}
+
+	private static < A extends ArrayDataAccess< ? > > void setPlaneCastType( PlanarAccess< A > img, int index, ArrayDataAccess< ? > arrayDataAccess )
+	{
+		img.setPlane( index, ( A ) arrayDataAccess );
+	}
+
+	private ArrayDataAccess wrapPixelsToAccess( Object pixels )
+	{
+		if ( pixels instanceof byte[] )
+			return new ByteArray( ( byte[] ) pixels );
+		if ( pixels instanceof short[] )
+			return new ShortArray( ( short[] ) pixels );
+		if ( pixels instanceof int[] )
+			return new IntArray( ( int[] ) pixels );
+		if ( pixels instanceof float[] )
+			return new FloatArray( ( float[] ) pixels );
+		throw new UnsupportedOperationException();
 	}
 
 	// Helper methods

--- a/src/main/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStack.java
@@ -50,6 +50,10 @@ import net.imglib2.Interval;
 import net.imglib2.img.Img;
 import net.imglib2.img.basictypeaccess.PlanarAccess;
 import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
+import net.imglib2.img.basictypeaccess.array.ByteArray;
+import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.IntArray;
+import net.imglib2.img.basictypeaccess.array.ShortArray;
 import net.imglib2.img.planar.PlanarImg;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.Type;
@@ -122,7 +126,7 @@ public class PlanarImgToVirtualStack extends AbstractVirtualStack
 
 	public static VirtualStack wrap( final PlanarImg< ?, ? > img )
 	{
-		return new PlanarImgToVirtualStack( img, x -> x - 1 );
+		return new PlanarImgToVirtualStack( img, x -> x );
 	}
 
 	// fields
@@ -148,9 +152,15 @@ public class PlanarImgToVirtualStack extends AbstractVirtualStack
 	// public methods
 
 	@Override
-	public Object getPixels( final int n )
+	protected Object getPixelsZeroBasedIndex( final int index )
 	{
-		return img.getPlane( indexer.applyAsInt( n ) ).getCurrentStorageArray();
+		return img.getPlane( indexer.applyAsInt( index ) ).getCurrentStorageArray();
+	}
+
+	@Override
+	protected void setPixelsZeroBasedIndex( int index, Object pixels )
+	{
+		// ignore
 	}
 
 	// Helper methods
@@ -174,14 +184,14 @@ public class PlanarImgToVirtualStack extends AbstractVirtualStack
 		if ( !checkAxisOrder( axes ) )
 			throw new IllegalArgumentException( "Unsupported axis order, first axis must be X, second axis must be Y, and then optionally, arbitrary ordered: channel, Z and time." );
 		if ( inPreferredOrder( axes ) )
-			return x -> x - 1;
+			return x -> x;
 		final int[] stackSizes = { dimension( imgPlus, Axes.CHANNEL ), dimension( imgPlus, Axes.Z ), dimension( imgPlus, Axes.TIME ) };
 		final int channelSkip = getSkip( imgPlus, Axes.CHANNEL );
 		final int zSkip = getSkip( imgPlus, Axes.Z );
 		final int timeSkip = getSkip( imgPlus, Axes.TIME );
 		return stackIndex -> {
 			final int[] stackPosition = new int[ 3 ];
-			IntervalIndexer.indexToPosition( stackIndex - 1, stackSizes, stackPosition );
+			IntervalIndexer.indexToPosition( stackIndex, stackSizes, stackPosition );
 			return channelSkip * stackPosition[ 0 ] + zSkip * stackPosition[ 1 ] + timeSkip * stackPosition[ 2 ];
 		};
 	}

--- a/src/test/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStackTest.java
@@ -133,4 +133,16 @@ public class PlanarImgToVirtualStackTest
 		// test
 		assertEquals( expected, img.cursor().next().get(), 0.0f );
 	}
+
+	@Test
+	public void testSetPixels() {
+		// setup
+		final PlanarImg< FloatType, FloatArray > img = PlanarImgs.floats( 1, 1 );
+		final ImagePlus imagePlus = PlanarImgToVirtualStack.wrap( new ImgPlus<>( img, "title" ) );
+		final float expected = 42.0f;
+		// process
+		imagePlus.getStack().setPixels( new float[] { expected }, 1 );
+		// test
+		assertEquals( expected, img.cursor().next().get(), 0.0f );
+	}
 }


### PR DESCRIPTION
Within the legacy user interface ij.plugin.Resizer is used to crop an image.
This currently produces wrap results.
This PR adds a functional implementation of AbstractVirtualStack#deleteSlice
to fix this issue. (Only the deletion of first and last slice is supported currently)