### PR TITLE
Fix unnecessary type conversion

### DIFF
--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ExecutorService;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.Converter;
 import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.util.Util;
@@ -74,8 +75,10 @@ public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< S, 
 
 	private static < T extends RealType< ? > > Converter< ? super T, UnsignedByteType > initConverter( T type )
 	{
-		if( type instanceof UnsignedByteType )
+		if ( type instanceof UnsignedByteType )
 			return (Converter) new ByteToByteConverter();
+		if ( type instanceof IntegerType )
+			return (Converter) new IntegerToByteConverter();
 		return new RealToByteConverter();
 	}
 
@@ -90,6 +93,22 @@ public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< S, 
 		}
 	}
 
+	private static class IntegerToByteConverter implements
+			Converter< IntegerType, UnsignedByteType >
+	{
+
+		@Override
+		public void convert( IntegerType input, UnsignedByteType output )
+		{
+			int value = input.getInteger();
+			if ( value < 0 )
+				value = 0;
+			else if ( value > 255 )
+				value = 255;
+			output.set( value );
+		}
+	}
+
 	private static class RealToByteConverter implements
 			Converter< RealType< ? >, UnsignedByteType >
 	{
@@ -97,12 +116,12 @@ public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< S, 
 		@Override
 		public void convert( final RealType< ? > input, final UnsignedByteType output )
 		{
-			double val = input.getRealDouble();
-			if ( val < 0 )
-				val = 0;
-			else if ( val > 255 )
-				val = 255;
-			output.setReal( val );
+			double value = input.getRealDouble();
+			if ( value < 0 )
+				value = 0;
+			else if ( value > 255 )
+				value = 255;
+			output.setReal( value );
 		}
 	}
 

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
@@ -41,6 +41,7 @@ import net.imglib2.converter.Converter;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.util.Util;
 
 /**
  * TODO
@@ -50,7 +51,9 @@ public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< S, 
 {
 	public static < T extends RealType< ? > > ImageJVirtualStackUnsignedByte< T > wrap( final RandomAccessibleInterval< T > source )
 	{
-		return new ImageJVirtualStackUnsignedByte<>( source, new ByteConverter() );
+		final Converter< ? super T, UnsignedByteType > converter =
+				initConverter( Util.getTypeFromInterval( source ) );
+		return new ImageJVirtualStackUnsignedByte<>( source, converter );
 	}
 
 	public static ImageJVirtualStackUnsignedByte< BitType > wrapAndScaleBitType( final RandomAccessibleInterval< BitType > source )
@@ -69,7 +72,25 @@ public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< S, 
 		setMinAndMax( 0, 255 );
 	}
 
-	private static class ByteConverter implements
+	private static < T extends RealType< ? > > Converter< ? super T, UnsignedByteType > initConverter( T type )
+	{
+		if( type instanceof UnsignedByteType )
+			return (Converter) new ByteToByteConverter();
+		return new RealToByteConverter();
+	}
+
+	private static class ByteToByteConverter implements
+			Converter< UnsignedByteType, UnsignedByteType >
+	{
+
+		@Override
+		public void convert( final UnsignedByteType input, final UnsignedByteType output )
+		{
+			output.set( input );
+		}
+	}
+
+	private static class RealToByteConverter implements
 			Converter< RealType< ? >, UnsignedByteType >
 	{
 

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
@@ -73,7 +73,7 @@ public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< S, 
 		setMinAndMax( 0, 255 );
 	}
 
-	private static < T extends RealType< ? > > Converter< ? super T, UnsignedByteType > initConverter( T type )
+	static < T extends RealType< ? > > Converter< ? super T, UnsignedByteType > initConverter( T type )
 	{
 		if ( type instanceof UnsignedByteType )
 			return (Converter) new ByteToByteConverter();

--- a/src/test/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByteTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByteTest.java
@@ -1,0 +1,86 @@
+/*
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2016 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.display.imagej;
+
+import ij.VirtualStack;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.list.ListImg;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.type.numeric.integer.IntType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.real.FloatType;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests {@link ImageJVirtualStackUnsignedByte}.
+ */
+public class ImageJVirtualStackUnsignedByteTest
+{
+	@Test
+	public void testByteToByteConverter()
+	{
+		testConversion( new UnsignedByteType() );
+	}
+
+	@Test
+	public void testIntegerToByteConverter()
+	{
+		testConversion( new IntType() );
+	}
+
+	@Test
+	public void testRealToByteConverter()
+	{
+		testConversion( new FloatType() );
+	}
+
+	private void testConversion( RealType< ? > pixel )
+	{
+		float expected = 42;
+		pixel.setReal( expected );
+		VirtualStack stack = ImageJVirtualStackUnsignedByte.wrap( asImage( pixel ) );
+		float actual = stack.getProcessor( 1 ).getf( 0, 0 );
+		assertEquals( expected, actual, 0 );
+	}
+
+	private < T > RandomAccessibleInterval< T > asImage( T pixel )
+	{
+		return new ListImg<>( Collections.singleton( pixel ), 1, 1 );
+	}
+}


### PR DESCRIPTION
This PR removes an unnecessary conversion from byte to double to byte when converting  and Img<UnsignedByteType> to ImagePlus.

This fixes https://github.com/imglib/imglib2-ij/issues/16

