### PR TITLE
Support SCIFIOCellImg (fix issue #16)

### DIFF
--- a/src/main/java/net/imglib2/img/display/imagej/CellImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/CellImgToVirtualStack.java
@@ -1,0 +1,165 @@
+/*-
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.display.imagej;
+
+import ij.ImagePlus;
+import net.imagej.ImgPlus;
+import net.imglib2.Dimensions;
+import net.imglib2.FinalDimensions;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessible;
+import net.imglib2.img.Img;
+import net.imglib2.img.basictypeaccess.array.ArrayDataAccess;
+import net.imglib2.img.cell.AbstractCellImg;
+import net.imglib2.img.cell.Cell;
+import net.imglib2.img.cell.CellGrid;
+import net.imglib2.img.planar.PlanarImg;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.NativeTypeFactory;
+import net.imglib2.util.Fraction;
+import net.imglib2.util.IntervalIndexer;
+import net.imglib2.util.Intervals;
+import net.imglib2.util.Util;
+
+import java.util.AbstractList;
+import java.util.List;
+
+/**
+ * Utility class to convert a {@link net.imglib2.img.cell.CellImg} (and SCIFIOCellImg,
+ * CachedCellImg) to ImagePlus. It is restricted to planar cells (where each
+ * cells contains exactly one image plane), and certain pixel types:
+ * UnsignedByteType, UnsignedShortType, ARGBType and FloatType.
+ *
+ * @see ImgToVirtualStack
+ * @see PlanarImgToVirtualStack
+ * @see ArrayImgToVirtualStack
+ */
+public class CellImgToVirtualStack
+{
+
+	/**
+	 * Returns true if {@link #wrap(ImgPlus)} supports the given image.
+	 */
+	public static boolean isSupported( ImgPlus< ? > imgPlus )
+	{
+		return isCellImgWithPlanarCells( imgPlus.getImg() ) &&
+				PlanarImgToVirtualStack.isSupported( toPlanarImgPlus( imgPlus ) );
+	}
+
+	private static boolean isCellImgWithPlanarCells( Img< ? > imgPlus )
+	{
+		return ( imgPlus instanceof AbstractCellImg ) &&
+				areCellsPlanar( ( ( AbstractCellImg ) imgPlus ).getCellGrid() );
+	}
+
+	private static boolean areCellsPlanar( CellGrid cellGrid )
+	{
+		for ( int i = 0; i < 2; i++ )
+			if ( cellGrid.cellDimension( i ) < cellGrid.imgDimension( i ) )
+				return false;
+		for ( int i = 2; i < cellGrid.numDimensions(); i++ )
+			if ( cellGrid.cellDimension( i ) != 1 && cellGrid.imgDimension( i ) != 1 )
+				return false;
+		return true;
+	}
+
+	/**
+	 * Wraps the given image as {@link ImagePlus}. The given image must be backed
+	 * by an {@link AbstractCellImg} with planar cells. The pixel type must be
+	 * UnsignedByte-, UnsignedShort-, ARGB- or FloatType. First two axes must be
+	 * X and Y (or unknown).
+	 */
+	public static ImagePlus wrap( ImgPlus< ? > imgPlus )
+	{
+		return PlanarImgToVirtualStack.wrap( toPlanarImgPlus( imgPlus ) );
+	}
+
+	private static < T > ImgPlus< T > toPlanarImgPlus( ImgPlus< T > image )
+	{
+		if ( !isCellImgWithPlanarCells( image.getImg() ) )
+			throw new IllegalArgumentException( "ERROR: Image must be a CellImg, with planar cells." );
+		return new ImgPlus< T >( toPlanar( ( AbstractCellImg ) image.getImg() ), image );
+	}
+
+	private static < T extends NativeType< T >, A extends ArrayDataAccess< A > > PlanarImg< ?, ? >
+	toPlanar( AbstractCellImg< T, A, ?, ? > cellImage )
+	{
+		final long[] dim = Intervals.dimensionsAsLongArray( cellImage );
+		final T type = Util.getTypeFromInterval( cellImage ).copy();
+		final Fraction entitiesPerPixel = type.getEntitiesPerPixel();
+		List< A > slices = new SlicesList<>( cellImage );
+		final PlanarImg< T, A > ts = new PlanarImg<>( slices, dim, entitiesPerPixel );
+		ts.setLinkedType( ( T ) ( ( NativeTypeFactory ) type.getNativeTypeFactory() ).createLinkedType( ts ) );
+		return ts;
+	}
+
+	private static class SlicesList< A extends ArrayDataAccess< ? > > extends AbstractList< A >
+	{
+		final RandomAccessible< ? extends Cell< A > > cells;
+
+		final Dimensions gridDim;
+
+		public SlicesList( AbstractCellImg< ?, A, ?, ? > cellImage )
+		{
+			cells = cellImage.getCells();
+			gridDim = new FinalDimensions( cellImage.getCellGrid().getGridDimensions() );
+		}
+
+		@Override
+		public A set( int index, A element )
+		{
+			final A destination = get( index );
+			System.arraycopy(
+					element.getCurrentStorageArray(), 0,
+					destination.getCurrentStorageArray(), 0,
+					Math.min( element.getArrayLength(), destination.getArrayLength() ) );
+			return destination;
+		}
+
+		@Override
+		public A get( int index )
+		{
+			RandomAccess< ? extends Cell< A > > ra = cells.randomAccess();
+			IntervalIndexer.indexToPosition( index, gridDim, ra );
+			return ra.get().getData();
+		}
+
+		@Override
+		public int size()
+		{
+			return ( int ) Intervals.numElements( gridDim );
+		}
+	}
+}

--- a/src/main/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStack.java
@@ -66,6 +66,15 @@ import net.imglib2.util.IntervalIndexer;
 import ij.ImagePlus;
 import ij.VirtualStack;
 
+/**
+ * Utility class to convert a {@link PlanarImg} to an {@link ImagePlus}
+ * without copying data. It is restricted to certain pixel types:
+ * UnsignedByteType, UnsignedShortType, ARGBType and FloatType.
+ *
+ * @see ArrayImgToVirtualStack
+ * @see ImgToVirtualStack
+ * @see CellImgToVirtualStack
+ */
 public class PlanarImgToVirtualStack extends AbstractVirtualStack
 {
 
@@ -73,9 +82,6 @@ public class PlanarImgToVirtualStack extends AbstractVirtualStack
 
 	/**
 	 * Returns true, if {@link #wrap(ImgPlus)} supports the given image.
-	 *
-	 * @see ArrayImgToVirtualStack
-	 * @see ImgToVirtualStack
 	 */
 	public static boolean isSupported( ImgPlus< ? > imgPlus )
 	{
@@ -101,8 +107,6 @@ public class PlanarImgToVirtualStack extends AbstractVirtualStack
 	 * supported.
 	 *
 	 * @see #isSupported(ImgPlus)
-	 * @see ArrayImgToVirtualStack
-	 * @see ImgToVirtualStack
 	 */
 	public static ImagePlus wrap( ImgPlus< ? > imgPlus )
 	{

--- a/src/test/java/net/imglib2/img/display/imagej/CellImgToVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/CellImgToVirtualStackTest.java
@@ -1,0 +1,176 @@
+/*-
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imglib2.img.display.imagej;
+
+import ij.ImagePlus;
+import ij.ImageStack;
+import net.imagej.ImgPlus;
+import net.imagej.axis.Axes;
+import net.imagej.axis.AxisType;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.img.Img;
+import net.imglib2.img.cell.CellImgFactory;
+import net.imglib2.type.numeric.IntegerType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.view.Views;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests {@link CellImgToVirtualStack}.
+ */
+public class CellImgToVirtualStackTest
+{
+
+	@Test
+	public void test3D() {
+		Img< UnsignedByteType > image = new CellImgFactory<>( new UnsignedByteType(), 3, 1, 1 ).create( 3, 1, 2 );
+		fill( image );
+		ImageStack stack = wrap( image );
+		assertArrayEquals( new byte[]{ 1, 2, 3 }, (byte[]) stack.getPixels( 1 ) );
+		assertArrayEquals( new byte[]{ 4, 5, 6 }, (byte[]) stack.getPixels( 2 ) );
+	}
+
+	private ImageStack wrap( Img< ? > image )
+	{
+		return CellImgToVirtualStack.wrap( ImgPlus.wrap( image ) ).getStack();
+	}
+
+	@Test
+	public void test5D() {
+		Img< UnsignedByteType > image = new CellImgFactory<>( new UnsignedByteType(), 2, 1, 1, 1, 1 ).create( 2, 1, 2, 3, 4 );
+		fill( image );
+		ImageStack stack = wrap( image );
+		assertArrayEquals( new byte[]{ 1, 2 }, (byte[]) stack.getPixels( 1 ) );
+		assertArrayEquals( new byte[]{ 3, 4 }, (byte[]) stack.getPixels( 2 ) );
+		assertArrayEquals( new byte[]{ 5, 6 }, (byte[]) stack.getPixels( 3 ) );
+	}
+
+	@Test
+	public void testFloatImg() {
+		Img< FloatType > image = new CellImgFactory<>( new FloatType(), 1, 1, 1 ).create( 1, 1, 1 );
+		image.firstElement().set( 42 );
+		ImageStack stack = wrap( image );
+		assertArrayEquals( new float[]{ 42 }, (float[]) stack.getPixels( 1 ), 0 );
+	}
+
+	@Test
+	public void testAxisOrder()
+	{
+		final Img< UnsignedByteType > img = new CellImgFactory<>( new UnsignedByteType(), 1, 1, 1, 1, 1).create( new long[] { 1, 1, 2, 3, 4 } );
+		fill( img );
+		final ImgPlus< UnsignedByteType > imgPlus = new ImgPlus<>( img, "title", new AxisType[] { Axes.X, Axes.Y, Axes.TIME, Axes.CHANNEL, Axes.Z } );
+		final ImagePlus imagePlus = CellImgToVirtualStack.wrap( imgPlus );
+		assertEquals( 2, imagePlus.getStack().getProcessor( imagePlus.getStackIndex( 1, 1, 2 ) ).get( 0, 0 ) );
+		assertEquals( 7, imagePlus.getStack().getProcessor( imagePlus.getStackIndex( 1, 2, 1 ) ).get( 0, 0 ) );
+		assertEquals( 3, imagePlus.getStack().getProcessor( imagePlus.getStackIndex( 2, 1, 1 ) ).get( 0, 0 ) );
+	}
+
+	@Test
+	public void testIsSupported()
+	{
+		assertTrue( CellImgToVirtualStack.isSupported( ImgPlus.wrap( new CellImgFactory<>( new UnsignedByteType(), 2, 2 ).create( 2, 2 ) ) ) );
+	}
+
+	@Test
+	public void testIsSupported_FloatType()
+	{
+		assertTrue( CellImgToVirtualStack.isSupported( ImgPlus.wrap( new CellImgFactory<>( new FloatType(), 2, 2 ).create( 2, 2 ) ) ) );
+	}
+
+	@Test
+	public void testIsSupported_UnsupportedType()
+	{
+		assertFalse( CellImgToVirtualStack.isSupported( ImgPlus.wrap( new CellImgFactory<>( new DoubleType(), 2, 2 ).create( 2, 2 ) ) ) );
+	}
+
+	@Test
+	public void testIsSupported_PlanarCells()
+	{
+		assertTrue( CellImgToVirtualStack.isSupported( ImgPlus.wrap( new CellImgFactory<>( new FloatType(), 7, 2 ).create( 2, 2 ) ) ) );
+		assertTrue( CellImgToVirtualStack.isSupported( ImgPlus.wrap( new CellImgFactory<>( new FloatType(), 2, 2, 3 ).create( 2, 2, 1 ) ) ) );
+	}
+
+	@Test
+	public void testIsSupported_NoPlanarCells() {
+		assertFalse( CellImgToVirtualStack.isSupported( ImgPlus.wrap( new CellImgFactory<>( new FloatType(), 1, 2 ).create( 2, 2 ) ) ) );
+		assertFalse( CellImgToVirtualStack.isSupported( ImgPlus.wrap( new CellImgFactory<>( new FloatType(), 2, 2, 3 ).create( 2, 2, 3 ) ) ) );
+	}
+
+	@Test
+	public void testIsSupported_WrongAxis() {
+		final Img< FloatType > cellImg = new CellImgFactory<>( new FloatType(), 2, 2, 3 ).create( 2, 2, 1 );
+		assertTrue( CellImgToVirtualStack.isSupported( new ImgPlus<>( cellImg, "title", new AxisType[]{ Axes.X, Axes.Y, Axes.unknown() } ) ) );
+		assertFalse( CellImgToVirtualStack.isSupported( new ImgPlus<>( cellImg, "title", new AxisType[]{ Axes.X, Axes.Z, Axes.TIME } ) ) );
+	}
+
+	private void fill( RandomAccessibleInterval< ? extends IntegerType< ? > > image )
+	{
+		int i = 1;
+		for( IntegerType< ? > pixel : Views.flatIterable( image ) )
+			pixel.setInteger( i++ );
+	}
+
+	@Test
+	public void testPersistence()
+	{
+		// setup
+		final Img< FloatType > img = new CellImgFactory<>( new FloatType() ).create( 1, 1, 1 );
+		final ImagePlus imagePlus = CellImgToVirtualStack.wrap( ImgPlus.wrap( img ) );
+		final float expected = 42.0f;
+		// process
+		imagePlus.getProcessor().setf( 0, 0, expected );
+		// test
+		assertEquals( expected, img.cursor().next().get(), 0.0f );
+	}
+
+	@Test
+	public void testSetPixels() {
+		// setup
+		final Img< FloatType > img = new CellImgFactory<>( new FloatType() ).create( 1, 1, 1 );
+		final ImagePlus imagePlus = CellImgToVirtualStack.wrap( new ImgPlus<>( img, "title" ) );
+		final float expected = 42.0f;
+		// process
+		imagePlus.getStack().setPixels( new float[] { expected }, 1 );
+		// test
+		assertEquals( expected, img.cursor().next().get(), 0.0f );
+	}
+}


### PR DESCRIPTION
Add class to support fast wrapping for CellImg to ImagePlus. (Without copying pixel buffers)
This only works for planar cells (where the image cells are exactly the planes of the image).

This feature is needed to display SCIFIOCellImg in imagej-legacy GUI without copying of pixel data.