### PR TITLE
Fix issue #27 and #16 (Implement getVoxels and setVoxels)

### DIFF
--- a/src/main/java/net/imglib2/img/display/imagej/AbstractVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/AbstractVirtualStack.java
@@ -40,6 +40,7 @@ import java.util.stream.IntStream;
 
 import ij.ImageStack;
 import ij.VirtualStack;
+import ij.process.ColorProcessor;
 import ij.process.ImageProcessor;
 
 /**
@@ -110,7 +111,8 @@ public abstract class AbstractVirtualStack extends VirtualStack
 
 		final Object pixels = getPixels( n );
 		final ImageProcessor processor = ImageProcessorUtils.initProcessor( width, height, pixels, colorModel );
-		processor.setMinAndMax( min, max );
+		if ( min != Double.MAX_VALUE && !( processor instanceof ColorProcessor ) )
+			processor.setMinAndMax( min, max );
 		return processor;
 	}
 

--- a/src/main/java/net/imglib2/img/display/imagej/AbstractVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/AbstractVirtualStack.java
@@ -103,12 +103,17 @@ public abstract class AbstractVirtualStack extends VirtualStack
 	@Override
 	public final void setPixels( final Object pixels, final int n )
 	{
-		setPixelsZeroBasedIndex( toZeroBasedIndex( n ), pixels );
+		if( isWritable() )
+			setPixelsZeroBasedIndex( toZeroBasedIndex( n ), pixels );
 	}
 
 	private int toZeroBasedIndex( int n )
 	{
 		return ( n - 1 ) + offset;
+	}
+
+	protected boolean isWritable() {
+		return true;
 	}
 
 	protected abstract Object getPixelsZeroBasedIndex( int index );
@@ -372,13 +377,15 @@ public abstract class AbstractVirtualStack extends VirtualStack
 	@Override
 	public void setVoxels( final int x0, final int y0, final int z0, final int w, final int h, final int d, final float[] voxels )
 	{
-		accessVoxels( x0, y0, z0, w, h, d, voxels, null, true );
+		if ( isWritable() )
+			accessVoxels( x0, y0, z0, w, h, d, voxels, null, true );
 	}
 
 	@Override
 	public void setVoxels( final int x0, final int y0, final int z0, final int w, final int h, final int d, final float[] voxels, final int channel )
 	{
-		accessVoxels( x0, y0, z0, w, h, d, voxels, channel, true );
+		if ( isWritable() )
+			accessVoxels( x0, y0, z0, w, h, d, voxels, channel, true );
 	}
 
 	private float[] accessVoxels( int x0, int y0, int z0, int w, int h, int d, float[] voxels, Integer optionalChannel, boolean setVoxel )

--- a/src/main/java/net/imglib2/img/display/imagej/AbstractVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/AbstractVirtualStack.java
@@ -353,7 +353,12 @@ public abstract class AbstractVirtualStack extends VirtualStack
 	@Override
 	public void setProcessor( final ImageProcessor ip, final int n )
 	{
-		// ignore
+		// NB: Try to behave like ImageStack.setProcessor
+		if (ip.getWidth() != width || ip.getHeight() != height)
+			throw new IllegalArgumentException("Wrong dimensions for this stack");
+		if (getBitDepth() != ip.getBitDepth())
+			throw new IllegalArgumentException("Wrong type for this stack");
+		setPixels( ip.getPixels(), n );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/display/imagej/ArrayImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ArrayImgToVirtualStack.java
@@ -104,7 +104,7 @@ public class ArrayImgToVirtualStack
 		final int sizeX = ( int ) img.dimension( 0 );
 		final int sizeY = ( int ) img.dimension( 1 );
 		final Object pixels = arrayImg.update( null ).getCurrentStorageArray();
-		final ImageProcessor processor = ImageProcessorUtils.initProcessor( sizeX, sizeY, pixels, null );
+		final ImageProcessor processor = ImageProcessorUtils.createImageProcessor( pixels, sizeX, sizeY, null );
 		final ImagePlus imagePlus = new ImagePlus( imgPlus.getName(), processor );
 		CalibrationUtils.copyCalibrationToImagePlus( imgPlus, imagePlus );
 		return imagePlus;

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJFunctions.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJFunctions.java
@@ -183,7 +183,7 @@ public class ImageJFunctions
 			final String title,
 			final ExecutorService service )
 	{
-		final ImageJVirtualStackFloat< T > stack = new ImageJVirtualStackFloat<>( img, converter, service );
+		final ImageJVirtualStackFloat stack = new ImageJVirtualStackFloat( img, converter, service );
 		final ImagePlus imp = new ImagePlus( title, stack );
 		imp.show();
 
@@ -281,7 +281,7 @@ public class ImageJFunctions
 			final String title,
 			final ExecutorService service )
 	{
-		final ImageJVirtualStackFloat< T > stack = ImageJVirtualStackFloat.wrap( img );
+		final ImageJVirtualStackFloat stack = ImageJVirtualStackFloat.wrap( img );
 		stack.setExecutorService( service );
 		return makeImagePlus( img, stack, title );
 	}
@@ -329,7 +329,7 @@ public class ImageJFunctions
 			final String title,
 			final ExecutorService service )
 	{
-		final ImageJVirtualStackFloat< T > stack = new ImageJVirtualStackFloat<>( img, converter, service );
+		final ImageJVirtualStackFloat stack = new ImageJVirtualStackFloat( img, converter, service );
 		return makeImagePlus( img, stack, title );
 	}
 
@@ -404,7 +404,7 @@ public class ImageJFunctions
 	public static ImagePlus wrapRGB( final RandomAccessibleInterval< ARGBType > img, final String title,
 			final ExecutorService service )
 	{
-		final ImageJVirtualStackARGB< ARGBType > stack = ImageJVirtualStackARGB.wrap( img );
+		final ImageJVirtualStackARGB stack = ImageJVirtualStackARGB.wrap( img );
 		stack.setExecutorService(service);
 		return makeImagePlus( img, stack, title );
 	}
@@ -458,7 +458,7 @@ public class ImageJFunctions
 			final String title,
 			final ExecutorService service )
 	{
-		final ImageJVirtualStackUnsignedByte< T > stack = ImageJVirtualStackUnsignedByte.wrap( img );
+		final ImageJVirtualStackUnsignedByte stack = ImageJVirtualStackUnsignedByte.wrap( img );
 		stack.setExecutorService( service );
 		return makeImagePlus( img, stack, title );
 	}
@@ -582,7 +582,7 @@ public class ImageJFunctions
 			final String title,
 			final ExecutorService service )
 	{
-		final ImageJVirtualStackUnsignedShort< T > stack = ImageJVirtualStackUnsignedShort.wrap( img );
+		final ImageJVirtualStackUnsignedShort stack = ImageJVirtualStackUnsignedShort.wrap( img );
 		stack.setExecutorService( service );
 		return makeImagePlus( img, stack, title );
 	}

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJFunctions.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJFunctions.java
@@ -77,6 +77,7 @@ import ij.VirtualStack;
  * Likewise, when an ImgLib2 {@link RandomAccessibleInterval} needs to be passed
  * to ImageJ 1.x, it can be wrapped into an {@link ImagePlus} via
  * {@code ImageJFunctions.wrap(img, title)}.
+ * (For details on this see {@link ImageJVirtualStack}).
  * </p>
  *
  * @author Tobis Pietzsch

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJFunctions.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJFunctions.java
@@ -42,10 +42,8 @@ import net.imglib2.Dimensions;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.converter.ComplexPowerGLogFloatConverter;
 import net.imglib2.converter.Converter;
-import net.imglib2.converter.RealFloatConverter;
+import net.imglib2.converter.Converters;
 import net.imglib2.converter.RealUnsignedByteConverter;
-import net.imglib2.converter.RealUnsignedShortConverter;
-import net.imglib2.converter.TypeIdentity;
 import net.imglib2.img.ImagePlusAdapter;
 import net.imglib2.img.Img;
 import net.imglib2.type.NativeType;
@@ -283,7 +281,8 @@ public class ImageJFunctions
 			final String title,
 			final ExecutorService service )
 	{
-		final ImageJVirtualStackFloat< T > stack = new ImageJVirtualStackFloat<>( img, new RealFloatConverter< T >(), service );
+		final ImageJVirtualStackFloat< T > stack = ImageJVirtualStackFloat.wrap( img );
+		stack.setExecutorService( service );
 		return makeImagePlus( img, stack, title );
 	}
 
@@ -352,12 +351,7 @@ public class ImageJFunctions
 			final String title,
 			final ExecutorService service )
 	{
-		final ImagePlus imp = wrapFloat( img, converter, title, service );
-		imp.show();
-		imp.getProcessor().resetMinAndMax();
-		imp.updateAndRepaintWindow();
-
-		return imp;
+		return showFloat( Converters.convert( img, converter, new FloatType() ), title, service );
 	}
 
 	public static < T > ImagePlus showFloat(
@@ -375,7 +369,11 @@ public class ImageJFunctions
 	public static < T extends RealType< T > > ImagePlus showFloat( final RandomAccessibleInterval< T > img, final String title,
 			final ExecutorService service )
 	{
-		return showFloat( img, new RealFloatConverter< T >(), title, service );
+		final ImagePlus imp = wrapFloat( img, title, service );
+		imp.show();
+		imp.getProcessor().resetMinAndMax();
+		imp.updateAndRepaintWindow();
+		return imp;
 	}
 
 	public static < T extends RealType< T > > ImagePlus showFloat( final RandomAccessibleInterval< T > img, final String title )
@@ -406,7 +404,9 @@ public class ImageJFunctions
 	public static ImagePlus wrapRGB( final RandomAccessibleInterval< ARGBType > img, final String title,
 			final ExecutorService service )
 	{
-		return wrapRGB( img, new TypeIdentity< ARGBType >(), title, service );
+		final ImageJVirtualStackARGB< ARGBType > stack = ImageJVirtualStackARGB.wrap( img );
+		stack.setExecutorService(service);
+		return makeImagePlus( img, stack, title );
 	}
 
 	public static ImagePlus wrapRGB( final RandomAccessibleInterval< ARGBType > img, final String title )
@@ -421,8 +421,7 @@ public class ImageJFunctions
 	public static < T > ImagePlus wrapRGB( final RandomAccessibleInterval< T > img, final Converter< T, ARGBType > converter, final String title,
 			final ExecutorService service )
 	{
-		final ImageJVirtualStackARGB< T > stack = new ImageJVirtualStackARGB<>( img, converter, service );
-		return makeImagePlus( img, stack, title );
+		return wrapRGB( Converters.convert( img, converter, new ARGBType() ), title, service );
 	}
 
 	public static < T > ImagePlus wrapRGB( final RandomAccessibleInterval< T > img, final Converter< T, ARGBType > converter, final String title )
@@ -459,7 +458,9 @@ public class ImageJFunctions
 			final String title,
 			final ExecutorService service )
 	{
-		return wrapUnsignedByte( img, new RealUnsignedByteConverter< T >( 0, 255 ), title, service );
+		final ImageJVirtualStackUnsignedByte< T > stack = ImageJVirtualStackUnsignedByte.wrap( img );
+		stack.setExecutorService( service );
+		return makeImagePlus( img, stack, title );
 	}
 
 	public static < T extends RealType< T > > ImagePlus wrapUnsignedByte(
@@ -499,8 +500,7 @@ public class ImageJFunctions
 			final String title,
 			final ExecutorService service )
 	{
-		final ImageJVirtualStackUnsignedByte< T > stack = new ImageJVirtualStackUnsignedByte<>( img, converter, service );
-		return makeImagePlus( img, stack, title );
+		return wrapUnsignedByte( Converters.convert( img, converter, new UnsignedByteType() ), title, service );
 	}
 
 	public static < T > ImagePlus wrapUnsignedByte(
@@ -521,12 +521,7 @@ public class ImageJFunctions
 			final String title,
 			final ExecutorService service )
 	{
-		final ImagePlus imp = wrapUnsignedByte( img, converter, title, service );
-		imp.show();
-		imp.getProcessor().resetMinAndMax();
-		imp.updateAndRepaintWindow();
-
-		return imp;
+		return showUnsignedByte( Converters.convert( img, converter, new UnsignedByteType() ), title, service );
 	}
 
 	public static < T > ImagePlus showUnsignedByte(
@@ -547,7 +542,11 @@ public class ImageJFunctions
 			final String title,
 			final ExecutorService service )
 	{
-		return showUnsignedByte( img, new RealUnsignedByteConverter< T >( 0, 255 ), title, service );
+		final ImagePlus imp = wrapUnsignedByte( img, title, service );
+		imp.show();
+		imp.getProcessor().resetMinAndMax();
+		imp.updateAndRepaintWindow();
+		return imp;
 	}
 
 	public static < T extends RealType< T > > ImagePlus showUnsignedByte(
@@ -583,7 +582,9 @@ public class ImageJFunctions
 			final String title,
 			final ExecutorService service )
 	{
-		return wrapUnsignedShort( img, new RealUnsignedShortConverter< T >( 0, 65535 ), title, service );
+		final ImageJVirtualStackUnsignedShort< T > stack = ImageJVirtualStackUnsignedShort.wrap( img );
+		stack.setExecutorService( service );
+		return makeImagePlus( img, stack, title );
 	}
 
 	public static < T extends RealType< T > > ImagePlus wrapUnsignedShort(
@@ -603,8 +604,7 @@ public class ImageJFunctions
 			final String title,
 			final ExecutorService service )
 	{
-		final ImageJVirtualStackUnsignedShort< T > stack = new ImageJVirtualStackUnsignedShort<>( img, converter, service );
-		return makeImagePlus( img, stack, title );
+		return wrapUnsignedShort( Converters.convert( img, converter, new UnsignedShortType() ), title, service );
 	}
 
 	public static < T > ImagePlus wrapUnsignedShort(
@@ -625,12 +625,7 @@ public class ImageJFunctions
 			final String title,
 			final ExecutorService service )
 	{
-		final ImagePlus imp = wrapUnsignedShort( img, converter, title, service );
-		imp.show();
-		imp.getProcessor().resetMinAndMax();
-		imp.updateAndRepaintWindow();
-
-		return imp;
+		return showUnsignedShort( Converters.convert( img, converter, new UnsignedShortType() ), title, service );
 	}
 
 	public static < T > ImagePlus showUnsignedShort(
@@ -651,7 +646,11 @@ public class ImageJFunctions
 			final String title,
 			final ExecutorService service )
 	{
-		return showUnsignedShort( img, new RealUnsignedShortConverter< T >( 0, 65535 ), title, service );
+		final ImagePlus imp = wrapUnsignedShort( img, title, service );
+		imp.show();
+		imp.getProcessor().resetMinAndMax();
+		imp.updateAndRepaintWindow();
+		return imp;
 	}
 
 	public static < T extends RealType< T > > ImagePlus showUnsignedShort(

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
@@ -59,7 +59,7 @@ import java.util.stream.LongStream;
  * TODO
  *
  */
-public class ImageJVirtualStack< S, T extends NativeType< T > > extends AbstractVirtualStack
+public class ImageJVirtualStack< T extends NativeType< T > > extends AbstractVirtualStack
 {
 
 	final private long[] higherSourceDimensions;
@@ -73,13 +73,13 @@ public class ImageJVirtualStack< S, T extends NativeType< T > > extends Abstract
 	protected ExecutorService service;
 
 	/* old constructor -> non-multithreaded projector */
-	protected ImageJVirtualStack( final RandomAccessibleInterval< S > source, final Converter< ? super S, T > converter,
+	protected < S > ImageJVirtualStack( final RandomAccessibleInterval< S > source, final Converter< ? super S, T > converter,
 			final T type, final int bitDepth )
 	{
 		this( Converters.convert( source, converter, type ), bitDepth );
 	}
 
-	protected ImageJVirtualStack( final RandomAccessibleInterval< S > source, final Converter< ? super S, T > converter,
+	protected < S > ImageJVirtualStack( final RandomAccessibleInterval< S > source, final Converter< ? super S, T > converter,
 			final T type, final int bitDepth, final ExecutorService service )
 	{
 		this( source, converter, type, bitDepth );

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
@@ -186,4 +186,18 @@ public class ImageJVirtualStack< S, T extends NativeType< T > > extends Abstract
 		}
 	}
 
+	@Override
+	protected RandomAccessibleInterval< T > getSliceZeroBasedIndex( int index )
+	{
+		RandomAccessibleInterval< T > origin = source;
+		// Get the 2D plane represented by the virtual array
+		if ( higherSourceDimensions.length > 0 )
+		{
+			final int[] position = new int[ higherSourceDimensions.length ];
+			IntervalIndexer.indexToPosition( index, higherSourceDimensions, position );
+			for ( int i = 0; i < position.length; i++ )
+				origin = Views.hyperSlice( origin, 2, position[ i ] );
+		}
+		return origin;
+	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
@@ -133,6 +133,7 @@ public class ImageJVirtualStack< T extends NativeType< T > > extends AbstractVir
 	/**
 	 * @return True if this VirtualStack will attempt to persist changes
 	 */
+	@Override
 	public boolean isWritable()
 	{
 		return isWritable;
@@ -177,13 +178,10 @@ public class ImageJVirtualStack< T extends NativeType< T > > extends AbstractVir
 	@Override
 	protected void setPixelsZeroBasedIndex( final int index, final Object pixels )
 	{
-		if ( isWritable() )
-		{
-			Img< T > img = ( Img< T > ) ImageProcessorUtils.initArrayImg( getWidth(), getHeight(), pixels );
-			// NB: The use of Converter and Projector2D is a bit surprising.
-			// As the converter intentionally uses the first parameter a output.
-			project( index, img, (o, i) -> o.set( i ) );
-		}
+		Img< T > img = ( Img< T > ) ImageProcessorUtils.initArrayImg( getWidth(), getHeight(), pixels );
+		// NB: The use of Converter and Projector2D is a bit surprising.
+		// As the converter intentionally uses the first parameter a output.
+		project( index, img, (o, i) -> o.set( i ) );
 	}
 
 	@Override

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
@@ -70,22 +70,23 @@ public class ImageJVirtualStack< S, T extends NativeType< T > > extends Abstract
 
 	private boolean isWritable = false;
 
-	final protected ExecutorService service;
+	protected ExecutorService service;
 
 	/* old constructor -> non-multithreaded projector */
 	protected ImageJVirtualStack( final RandomAccessibleInterval< S > source, final Converter< ? super S, T > converter,
 			final T type, final int bitDepth )
 	{
-		this( source, converter, type, bitDepth, null );
+		this( Converters.convert( source, converter, type ), bitDepth );
 	}
 
 	protected ImageJVirtualStack( final RandomAccessibleInterval< S > source, final Converter< ? super S, T > converter,
 			final T type, final int bitDepth, final ExecutorService service )
 	{
-		this( Converters.convert( source, converter, type ), bitDepth, service);
+		this( source, converter, type, bitDepth );
+		setExecutorService(service);
 	}
 
-	protected ImageJVirtualStack( final RandomAccessibleInterval< T > source, final int bitDepth, final ExecutorService service )
+	protected ImageJVirtualStack( final RandomAccessibleInterval< T > source, final int bitDepth )
 	{
 		super( ( int ) source.dimension( 0 ), ( int ) source.dimension( 1 ), multiply( initHigherDimensions( source ) ), bitDepth );
 		// if the source interval is not zero-min, we wrap it into a view that
@@ -95,7 +96,6 @@ public class ImageJVirtualStack< S, T extends NativeType< T > > extends Abstract
 		this.source = zeroMin( source );
 		this.type = Util.getTypeFromInterval( source );
 		this.higherSourceDimensions = initHigherDimensions( source );
-		this.service = service;
 	}
 
 	private static int multiply( final long[] higherSourceDimensions )
@@ -113,6 +113,11 @@ public class ImageJVirtualStack< S, T extends NativeType< T > > extends Abstract
 	private static < S > RandomAccessibleInterval< S > zeroMin( final RandomAccessibleInterval< S > source )
 	{
 		return Views.isZeroMin( source ) ? source : Views.zeroMin( source );
+	}
+
+	public void setExecutorService( ExecutorService service )
+	{
+		this.service = service;
 	}
 
 	/**

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackARGB.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackARGB.java
@@ -64,7 +64,7 @@ public class ImageJVirtualStackARGB< S > extends ImageJVirtualStack< S, ARGBType
 
 	private ImageJVirtualStackARGB( final RandomAccessibleInterval< ARGBType > source )
 	{
-		super( source, 24, null );
+		super( source, 24 );
 		setMinAndMax( 0, 255 );
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackARGB.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackARGB.java
@@ -44,7 +44,7 @@ import net.imglib2.type.numeric.ARGBType;
  * TODO
  *
  */
-public class ImageJVirtualStackARGB< S > extends ImageJVirtualStack< S, ARGBType >
+public class ImageJVirtualStackARGB< S > extends ImageJVirtualStack< ARGBType >
 {
 	public static ImageJVirtualStackARGB< ARGBType > wrap( final RandomAccessibleInterval< ARGBType > source )
 	{

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackARGB.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackARGB.java
@@ -44,19 +44,19 @@ import net.imglib2.type.numeric.ARGBType;
  * TODO
  *
  */
-public class ImageJVirtualStackARGB< S > extends ImageJVirtualStack< ARGBType >
+public class ImageJVirtualStackARGB extends ImageJVirtualStack< ARGBType >
 {
-	public static ImageJVirtualStackARGB< ARGBType > wrap( final RandomAccessibleInterval< ARGBType > source )
+	public static ImageJVirtualStackARGB wrap( final RandomAccessibleInterval< ARGBType > source )
 	{
-		return new ImageJVirtualStackARGB<>( source );
+		return new ImageJVirtualStackARGB( source );
 	}
 
-	public ImageJVirtualStackARGB( final RandomAccessibleInterval< S > source, final Converter< ? super S, ARGBType > converter )
+	public < S > ImageJVirtualStackARGB( final RandomAccessibleInterval< S > source, final Converter< ? super S, ARGBType > converter )
 	{
 		this( source, converter, null );
 	}
 
-	public ImageJVirtualStackARGB( final RandomAccessibleInterval< S > source, final Converter< ? super S, ARGBType > converter, final ExecutorService service )
+	public < S > ImageJVirtualStackARGB( final RandomAccessibleInterval< S > source, final Converter< ? super S, ARGBType > converter, final ExecutorService service )
 	{
 		super( source, converter, new ARGBType(), 24, service );
 		setMinAndMax( 0, 255 );

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackARGB.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackARGB.java
@@ -48,7 +48,7 @@ public class ImageJVirtualStackARGB< S > extends ImageJVirtualStack< S, ARGBType
 {
 	public static ImageJVirtualStackARGB< ARGBType > wrap( final RandomAccessibleInterval< ARGBType > source )
 	{
-		return new ImageJVirtualStackARGB<>( source, ( input, output ) -> output.set( input ) );
+		return new ImageJVirtualStackARGB<>( source );
 	}
 
 	public ImageJVirtualStackARGB( final RandomAccessibleInterval< S > source, final Converter< ? super S, ARGBType > converter )
@@ -59,6 +59,12 @@ public class ImageJVirtualStackARGB< S > extends ImageJVirtualStack< S, ARGBType
 	public ImageJVirtualStackARGB( final RandomAccessibleInterval< S > source, final Converter< ? super S, ARGBType > converter, final ExecutorService service )
 	{
 		super( source, converter, new ARGBType(), 24, service );
+		setMinAndMax( 0, 255 );
+	}
+
+	private ImageJVirtualStackARGB( final RandomAccessibleInterval< ARGBType > source )
+	{
+		super( source, 24, null );
 		setMinAndMax( 0, 255 );
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackFloat.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackFloat.java
@@ -58,7 +58,7 @@ import net.imglib2.view.Views;
  * TODO
  *
  */
-public class ImageJVirtualStackFloat< S > extends ImageJVirtualStack< S, FloatType >
+public class ImageJVirtualStackFloat< S > extends ImageJVirtualStack< FloatType >
 {
 	public static < T extends RealType< ? > > ImageJVirtualStackFloat< T > wrap( final RandomAccessibleInterval< T > source )
 	{

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackFloat.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackFloat.java
@@ -85,9 +85,9 @@ public class ImageJVirtualStackFloat< S > extends ImageJVirtualStack< S, FloatTy
 		setMinAndMax( 0, 1 );
 	}
 
-	public ImageJVirtualStackFloat( final RandomAccessibleInterval< FloatType > source )
+	private ImageJVirtualStackFloat( final RandomAccessibleInterval< FloatType > source )
 	{
-		super( source, 32, null );
+		super( source, 32 );
 		setMinAndMax( 0, 1 );
 	}
 

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackFloat.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackFloat.java
@@ -58,11 +58,11 @@ import net.imglib2.view.Views;
  * TODO
  *
  */
-public class ImageJVirtualStackFloat< S > extends ImageJVirtualStack< FloatType >
+public class ImageJVirtualStackFloat extends ImageJVirtualStack< FloatType >
 {
-	public static < T extends RealType< ? > > ImageJVirtualStackFloat< T > wrap( final RandomAccessibleInterval< T > source )
+	public static < T extends RealType< ? > > ImageJVirtualStackFloat wrap( final RandomAccessibleInterval< T > source )
 	{
-		return new ImageJVirtualStackFloat<>( toFloat(source) );
+		return new ImageJVirtualStackFloat( toFloat(source) );
 	}
 
 	private static < T extends RealType< ? > > RandomAccessibleInterval<FloatType> toFloat( RandomAccessibleInterval<T> source )
@@ -72,13 +72,13 @@ public class ImageJVirtualStackFloat< S > extends ImageJVirtualStack< FloatType 
 		return Converters.convert( source, new ToFloatSamplerConverter( Util.getTypeFromInterval( source )));
 	}
 
-	public ImageJVirtualStackFloat( final RandomAccessibleInterval< S > source,
+	public < S > ImageJVirtualStackFloat( final RandomAccessibleInterval< S > source,
 			final Converter< ? super S, FloatType > converter )
 	{
 		this( source, converter, null );
 	}
 
-	public ImageJVirtualStackFloat( final RandomAccessibleInterval< S > source,
+	public < S > ImageJVirtualStackFloat( final RandomAccessibleInterval< S > source,
 			final Converter< ? super S, FloatType > converter, final ExecutorService service )
 	{
 		super( source, converter, new FloatType(), 32, service );
@@ -91,7 +91,7 @@ public class ImageJVirtualStackFloat< S > extends ImageJVirtualStack< FloatType 
 		setMinAndMax( 0, 1 );
 	}
 
-	public void setMinMax( final RandomAccessibleInterval< S > source, final Converter< S, FloatType > converter )
+	public < S > void setMinMax( final RandomAccessibleInterval< S > source, final Converter< S, FloatType > converter )
 	{
 		if ( service != null )
 		{
@@ -126,7 +126,7 @@ public class ImageJVirtualStackFloat< S > extends ImageJVirtualStack< FloatType 
 		}
 	}
 
-	private void setMinMaxMT( final RandomAccessibleInterval< S > source, final Converter< S, FloatType > converter )
+	private < S > void setMinMaxMT( final RandomAccessibleInterval< S > source, final Converter< S, FloatType > converter )
 	{
 		final long nTasks = Runtime.getRuntime().availableProcessors();
 		long size = 1;

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
@@ -52,11 +52,11 @@ import java.util.concurrent.ExecutorService;
  * TODO
  *
  */
-public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< UnsignedByteType >
+public class ImageJVirtualStackUnsignedByte extends ImageJVirtualStack< UnsignedByteType >
 {
-	public static < T extends RealType< ? > > ImageJVirtualStackUnsignedByte< T > wrap( final RandomAccessibleInterval< T > source )
+	public static < T extends RealType< ? > > ImageJVirtualStackUnsignedByte wrap( final RandomAccessibleInterval< T > source )
 	{
-		return new ImageJVirtualStackUnsignedByte<>( toUnsignedByteType( source ) );
+		return new ImageJVirtualStackUnsignedByte( toUnsignedByteType( source ) );
 	}
 
 	private static < T extends RealType< ? > > RandomAccessibleInterval< UnsignedByteType > toUnsignedByteType( RandomAccessibleInterval< T > source )
@@ -66,17 +66,17 @@ public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< Uns
 		return Converters.convert(source, new ToUnsignedByteSamplerConverter( Util.getTypeFromInterval( source ) ) );
 	}
 
-	public static ImageJVirtualStackUnsignedByte< BitType > wrapAndScaleBitType( final RandomAccessibleInterval< BitType > source )
+	public static ImageJVirtualStackUnsignedByte wrapAndScaleBitType( final RandomAccessibleInterval< BitType > source )
 	{
-		return new ImageJVirtualStackUnsignedByte<>( Converters.convert(source, new ToBitByteSamplerConverter()) );
+		return new ImageJVirtualStackUnsignedByte( Converters.convert(source, new ToBitByteSamplerConverter()) );
 	}
 
-	public ImageJVirtualStackUnsignedByte( final RandomAccessibleInterval< S > source, final Converter< ? super S, UnsignedByteType > converter )
+	public < S > ImageJVirtualStackUnsignedByte( final RandomAccessibleInterval< S > source, final Converter< ? super S, UnsignedByteType > converter )
 	{
 		this( source, converter, null );
 	}
 
-	public ImageJVirtualStackUnsignedByte( final RandomAccessibleInterval< S > source, final Converter< ? super S, UnsignedByteType > converter, final ExecutorService service )
+	public < S > ImageJVirtualStackUnsignedByte( final RandomAccessibleInterval< S > source, final Converter< ? super S, UnsignedByteType > converter, final ExecutorService service )
 	{
 		super( source, converter, new UnsignedByteType(), 8, service );
 		setMinAndMax( 0, 255 );

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
@@ -34,13 +34,19 @@
 
 package net.imglib2.img.display.imagej;
 
-import java.util.concurrent.ExecutorService;
-
 import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.Sampler;
 import net.imglib2.converter.Converter;
+import net.imglib2.converter.Converters;
+import net.imglib2.converter.readwrite.SamplerConverter;
+import net.imglib2.img.basictypeaccess.ByteAccess;
+import net.imglib2.type.BooleanType;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.util.Util;
+
+import java.util.concurrent.ExecutorService;
 
 /**
  * TODO
@@ -50,12 +56,19 @@ public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< S, 
 {
 	public static < T extends RealType< ? > > ImageJVirtualStackUnsignedByte< T > wrap( final RandomAccessibleInterval< T > source )
 	{
-		return new ImageJVirtualStackUnsignedByte<>( source, new ByteConverter() );
+		return new ImageJVirtualStackUnsignedByte<>( toUnsignedByteType( source ) );
+	}
+
+	private static < T extends RealType< ? > > RandomAccessibleInterval< UnsignedByteType > toUnsignedByteType( RandomAccessibleInterval< T > source )
+	{
+		if( Util.getTypeFromInterval( source ) instanceof UnsignedByteType )
+			return ( RandomAccessibleInterval< UnsignedByteType > ) source;
+		return Converters.convert(source, new ToUnsignedByteSamplerConverter( Util.getTypeFromInterval( source ) ) );
 	}
 
 	public static ImageJVirtualStackUnsignedByte< BitType > wrapAndScaleBitType( final RandomAccessibleInterval< BitType > source )
 	{
-		return new ImageJVirtualStackUnsignedByte<>( source, new BitToByteConverter() );
+		return new ImageJVirtualStackUnsignedByte<>( Converters.convert(source, new ToBitByteSamplerConverter()) );
 	}
 
 	public ImageJVirtualStackUnsignedByte( final RandomAccessibleInterval< S > source, final Converter< ? super S, UnsignedByteType > converter )
@@ -69,30 +82,73 @@ public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< S, 
 		setMinAndMax( 0, 255 );
 	}
 
-	private static class ByteConverter implements
-			Converter< RealType< ? >, UnsignedByteType >
+	private ImageJVirtualStackUnsignedByte( final RandomAccessibleInterval< UnsignedByteType > source )
+	{
+		super( source, 8, null );
+		setMinAndMax( 0, 255 );
+	}
+
+	private static class ToUnsignedByteSamplerConverter implements SamplerConverter< RealType, UnsignedByteType >
 	{
 
+		private final double min;
+		private final double max;
+
+		ToUnsignedByteSamplerConverter( RealType<?> type ) {
+			min = type.getMinValue();
+			max = type.getMaxValue();
+		}
+
 		@Override
-		public void convert( final RealType< ? > input, final UnsignedByteType output )
+		public UnsignedByteType convert( Sampler< ? extends RealType > sampler )
 		{
-			double val = input.getRealDouble();
-			if ( val < 0 )
-				val = 0;
-			else if ( val > 255 )
-				val = 255;
-			output.setReal( val );
+			return new UnsignedByteType( new ByteAccess()
+			{
+				@Override
+				public byte getValue( int index )
+				{
+					double val = sampler.get().getRealDouble() + 0.5;
+					if ( val < 0 )
+						val = 0;
+					else if ( val > 255 )
+						val = 255;
+					return (byte) val;
+				}
+
+				@Override
+				public void setValue( int index, byte value )
+				{
+					double val = value;
+					if ( val < min )
+						val = min;
+					else if ( val > max )
+						val = max;
+					sampler.get().setReal( val );
+				}
+			} );
 		}
 	}
 
-	private static class BitToByteConverter implements
-			Converter< BitType, UnsignedByteType >
+	private static class ToBitByteSamplerConverter implements SamplerConverter< BooleanType<?>, UnsignedByteType >
 	{
 
 		@Override
-		public void convert( final BitType input, final UnsignedByteType output )
+		public UnsignedByteType convert( Sampler< ? extends BooleanType<?> > sampler )
 		{
-			output.set( input.get() ? 255 : 0 );
+			return new UnsignedByteType( new ByteAccess()
+			{
+				@Override
+				public byte getValue( int index )
+				{
+					return sampler.get().get() ? (byte) 255 : 0;
+				}
+
+				@Override
+				public void setValue( int index, byte value )
+				{
+					sampler.get().set( value != 0 );
+				}
+			} );
 		}
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
@@ -52,7 +52,7 @@ import java.util.concurrent.ExecutorService;
  * TODO
  *
  */
-public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< S, UnsignedByteType >
+public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< UnsignedByteType >
 {
 	public static < T extends RealType< ? > > ImageJVirtualStackUnsignedByte< T > wrap( final RandomAccessibleInterval< T > source )
 	{

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedByte.java
@@ -84,7 +84,7 @@ public class ImageJVirtualStackUnsignedByte< S > extends ImageJVirtualStack< S, 
 
 	private ImageJVirtualStackUnsignedByte( final RandomAccessibleInterval< UnsignedByteType > source )
 	{
-		super( source, 8, null );
+		super( source, 8 );
 		setMinAndMax( 0, 255 );
 	}
 

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedShort.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedShort.java
@@ -52,11 +52,11 @@ import net.imglib2.util.Util;
  * TODO
  *
  */
-public class ImageJVirtualStackUnsignedShort< S > extends ImageJVirtualStack< UnsignedShortType >
+public class ImageJVirtualStackUnsignedShort extends ImageJVirtualStack< UnsignedShortType >
 {
-	public static < T extends RealType< ? > > ImageJVirtualStackUnsignedShort< T > wrap( final RandomAccessibleInterval< T > source )
+	public static < T extends RealType< ? > > ImageJVirtualStackUnsignedShort wrap( final RandomAccessibleInterval< T > source )
 	{
-		final ImageJVirtualStackUnsignedShort< T > result = new ImageJVirtualStackUnsignedShort<>( toUnsignedShort( source ) );
+		final ImageJVirtualStackUnsignedShort result = new ImageJVirtualStackUnsignedShort( toUnsignedShort( source ) );
 		result.initMinMax( Util.getTypeFromInterval( source ) );
 		return result;
 	}
@@ -68,12 +68,12 @@ public class ImageJVirtualStackUnsignedShort< S > extends ImageJVirtualStack< Un
 		return Converters.convert( source, new ShortConverter( Util.getTypeFromInterval( source ) ) );
 	}
 
-	public ImageJVirtualStackUnsignedShort( final RandomAccessibleInterval< S > source, final Converter< ? super S, UnsignedShortType > converter )
+	public < S > ImageJVirtualStackUnsignedShort( final RandomAccessibleInterval< S > source, final Converter< ? super S, UnsignedShortType > converter )
 	{
 		this( source, converter, null );
 	}
 
-	public ImageJVirtualStackUnsignedShort( final RandomAccessibleInterval< S > source, final Converter< ? super S, UnsignedShortType > converter, final ExecutorService service )
+	public < S > ImageJVirtualStackUnsignedShort( final RandomAccessibleInterval< S > source, final Converter< ? super S, UnsignedShortType > converter, final ExecutorService service )
 	{
 		super( source, converter, new UnsignedShortType(), 16, service );
 		initMinMax( Util.getTypeFromInterval( source ) );

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedShort.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedShort.java
@@ -52,7 +52,7 @@ import net.imglib2.util.Util;
  * TODO
  *
  */
-public class ImageJVirtualStackUnsignedShort< S > extends ImageJVirtualStack< S, UnsignedShortType >
+public class ImageJVirtualStackUnsignedShort< S > extends ImageJVirtualStack< UnsignedShortType >
 {
 	public static < T extends RealType< ? > > ImageJVirtualStackUnsignedShort< T > wrap( final RandomAccessibleInterval< T > source )
 	{

--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedShort.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStackUnsignedShort.java
@@ -81,7 +81,7 @@ public class ImageJVirtualStackUnsignedShort< S > extends ImageJVirtualStack< S,
 
 	private ImageJVirtualStackUnsignedShort( final RandomAccessibleInterval< UnsignedShortType > source )
 	{
-		super( source, 16, null );
+		super( source, 16 );
 	}
 
 	private void initMinMax( Object s )

--- a/src/main/java/net/imglib2/img/display/imagej/ImageProcessorUtils.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageProcessorUtils.java
@@ -36,6 +36,8 @@ package net.imglib2.img.display.imagej;
 
 import java.awt.image.ColorModel;
 
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.Type;
 import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
@@ -72,5 +74,18 @@ public class ImageProcessorUtils
 	{
 		return ( type instanceof UnsignedByteType ) || ( type instanceof UnsignedShortType ) ||
 				( type instanceof ARGBType ) || ( type instanceof FloatType );
+	}
+
+	public static Img< ? > initArrayImg( final int sizeX, final int sizeY, final Object pixels )
+	{
+		if ( pixels instanceof int[] )
+			return ArrayImgs.argbs( ( int[] ) pixels, sizeX, sizeY );
+		if ( pixels instanceof byte[] )
+			return ArrayImgs.unsignedBytes( ( byte[] ) pixels, sizeX, sizeY );
+		if ( pixels instanceof short[] )
+			return ArrayImgs.unsignedShorts( ( short[] ) pixels, sizeX, sizeY );
+		if ( pixels instanceof float[] )
+			return ArrayImgs.floats( ( float[] ) pixels, sizeX, sizeY );
+		throw new IllegalArgumentException( "unsupported pixel type" );
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImageProcessorUtils.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageProcessorUtils.java
@@ -34,8 +34,11 @@
 
 package net.imglib2.img.display.imagej;
 
-import java.awt.image.ColorModel;
-
+import ij.process.ByteProcessor;
+import ij.process.ColorProcessor;
+import ij.process.FloatProcessor;
+import ij.process.ImageProcessor;
+import ij.process.ShortProcessor;
 import net.imglib2.img.Img;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.type.Type;
@@ -44,11 +47,7 @@ import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.type.numeric.real.FloatType;
 
-import ij.process.ByteProcessor;
-import ij.process.ColorProcessor;
-import ij.process.FloatProcessor;
-import ij.process.ImageProcessor;
-import ij.process.ShortProcessor;
+import java.awt.image.ColorModel;
 
 public class ImageProcessorUtils
 {
@@ -57,35 +56,62 @@ public class ImageProcessorUtils
 		// prevent from instantiation
 	}
 
-	public static ImageProcessor initProcessor( final int sizeX, final int sizeY, final Object pixels, final ColorModel colorModel )
+	/**
+	 * Creates an {@link ImageProcessor}.
+	 *
+	 * @param pixels     The parameter must be an array: byte[], short[], int[] or float[].
+	 *                   The array length must equal width * height.
+	 *                   The array will be used by the {@link ImageProcessor} to read and store the pixel values.
+	 * @param width      Width of the returned {@link ImageProcessor}.
+	 * @param height     Height of the returned {@link ImageProcessor}.
+	 * @param colorModel {@link ColorModel} used by the returned {@link ImageProcessor}.
+	 * @return Will return a {@link ByteProcessor}, {@link ShortProcessor}, {@link ColorProcessor} or {@link FloatProcessor}.
+	 * The concrete type is determined by the type of the array given as pixels.
+	 */
+	public static ImageProcessor createImageProcessor( final Object pixels, final int width, final int height, final ColorModel colorModel )
 	{
 		if ( pixels instanceof byte[] )
-			return new ByteProcessor( sizeX, sizeY, ( byte[] ) pixels, colorModel );
+			return new ByteProcessor( width, height, ( byte[] ) pixels, colorModel );
 		if ( pixels instanceof short[] )
-			return new ShortProcessor( sizeX, sizeY, ( short[] ) pixels, colorModel );
+			return new ShortProcessor( width, height, ( short[] ) pixels, colorModel );
 		if ( pixels instanceof int[] )
-			return new ColorProcessor( sizeX, sizeY, ( int[] ) pixels );
+			return new ColorProcessor( width, height, ( int[] ) pixels );
 		if ( pixels instanceof float[] )
-			return new FloatProcessor( sizeX, sizeY, ( float[] ) pixels, colorModel );
+			return new FloatProcessor( width, height, ( float[] ) pixels, colorModel );
 		throw new IllegalArgumentException( "unsupported color type" );
 	}
 
+	/**
+	 * Returns true if the given ImgLib2 pixel type is also supported by ImageJ1.
+	 */
 	public static boolean isSupported( final Type< ? > type )
 	{
 		return ( type instanceof UnsignedByteType ) || ( type instanceof UnsignedShortType ) ||
 				( type instanceof ARGBType ) || ( type instanceof FloatType );
 	}
 
-	public static Img< ? > initArrayImg( final int sizeX, final int sizeY, final Object pixels )
+	/**
+	 * Creates a two dimensional {@link Img} that wraps around the array given as pixels.
+	 * Only supports UnsignedByteType, UnsignedShortType, FloatType and ARGBType.
+	 * This method is like {@link #createImageProcessor(Object, int, int, ColorModel)} but
+	 * creates an imglib2 {@link Img} instead of an {@link ImageProcessor}.
+	 *
+	 * @param pixels The parameter must be an array: byte[], short[], int[] or float[].
+	 *               The array length must equal width * height.
+	 *               The array will be used by the {@link Img} to read and store the pixel values.
+	 * @param width  Width of the returned {@link Img}.
+	 * @param height Height of the returned {@link Img}.
+	 */
+	public static Img< ? > createImg( final Object pixels, final int width, final int height )
 	{
 		if ( pixels instanceof int[] )
-			return ArrayImgs.argbs( ( int[] ) pixels, sizeX, sizeY );
+			return ArrayImgs.argbs( ( int[] ) pixels, width, height );
 		if ( pixels instanceof byte[] )
-			return ArrayImgs.unsignedBytes( ( byte[] ) pixels, sizeX, sizeY );
+			return ArrayImgs.unsignedBytes( ( byte[] ) pixels, width, height );
 		if ( pixels instanceof short[] )
-			return ArrayImgs.unsignedShorts( ( short[] ) pixels, sizeX, sizeY );
+			return ArrayImgs.unsignedShorts( ( short[] ) pixels, width, height );
 		if ( pixels instanceof float[] )
-			return ArrayImgs.floats( ( float[] ) pixels, sizeX, sizeY );
+			return ArrayImgs.floats( ( float[] ) pixels, width, height );
 		throw new IllegalArgumentException( "unsupported pixel type" );
 	}
 }

--- a/src/main/java/net/imglib2/img/display/imagej/ImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImgToVirtualStack.java
@@ -115,7 +115,7 @@ public class ImgToVirtualStack
 		final Object type = rai.randomAccess().get();
 		if ( type instanceof RealType )
 		{
-			final ImageJVirtualStack< ?, ? > result = createVirtualStackRealType( cast( rai ) );
+			final ImageJVirtualStack< ? > result = createVirtualStackRealType( cast( rai ) );
 			result.setWritable( true );
 			return result;
 		}
@@ -132,7 +132,7 @@ public class ImgToVirtualStack
 		return out;
 	}
 
-	private static ImageJVirtualStack< ?, ? > createVirtualStackRealType( final RandomAccessibleInterval< ? extends RealType< ? > > rai )
+	private static ImageJVirtualStack< ? > createVirtualStackRealType( final RandomAccessibleInterval< ? extends RealType< ? > > rai )
 	{
 		final RealType< ? extends RealType< ? > > type = rai.randomAccess().get();
 		final int bitDepth = type.getBitsPerPixel();

--- a/src/main/java/net/imglib2/img/display/imagej/ImgToVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImgToVirtualStack.java
@@ -103,9 +103,9 @@ public class ImgToVirtualStack
 		return result;
 	}
 
-	private static ImageJVirtualStackUnsignedByte< BitType > createVirtualStackBits( final RandomAccessibleInterval< BitType > sorted )
+	private static ImageJVirtualStackUnsignedByte createVirtualStackBits( final RandomAccessibleInterval< BitType > sorted )
 	{
-		final ImageJVirtualStackUnsignedByte< BitType > stack = ImageJVirtualStackUnsignedByte.wrapAndScaleBitType( sorted );
+		final ImageJVirtualStackUnsignedByte stack = ImageJVirtualStackUnsignedByte.wrapAndScaleBitType( sorted );
 		stack.setWritable( true );
 		return stack;
 	}

--- a/src/test/java/net/imglib2/img/display/imagej/AbstractVirtualStackGetSetVoxelsTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/AbstractVirtualStackGetSetVoxelsTest.java
@@ -1,0 +1,186 @@
+/*-
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.display.imagej;
+
+import ij.ImageStack;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Test the methods {@link AbstractVirtualStack#getVoxels}
+ * and {@link AbstractVirtualStack#setVoxels} of class
+ * {@link AbstractVirtualStack}.
+ *
+ * @author Matthias Arzt
+ */
+public class AbstractVirtualStackGetSetVoxelsTest
+{
+
+	@Test
+	public void testGetVoxelsBytes()
+	{
+		final byte[][] pixels = { { 42 } };
+		ImageStack stack = TestVirtualStack.bytes( 1, 1, pixels );
+		float[] voxels = stack.getVoxels( 0, 0, 0, 1, 1, 1, null );
+		assertArrayEquals( new float[] { 42 }, voxels, 0 );
+	}
+
+	@Test
+	public void testGetVoxelsARGB()
+	{
+		final ImageStack stack = TestVirtualStack.ints( 1, 1, new int[][] { { 0xff010203 } } );
+		float[] voxels = stack.getVoxels( 0, 0, 0, 1, 1, 1, null );
+		assertArrayEquals( new float[] { 0xff010203 }, voxels, 0 );
+	}
+
+	@Test
+	public void testGetVoxels()
+	{
+		final byte[][] bytes = { { 0, 1, 2, 3 }, { 4, 5, 6, 7 } };
+		final ImageStack stack = TestVirtualStack.bytes( 2, 2, bytes );
+		float[] voxels = new float[ 8 ];
+		stack.getVoxels( 0, 0, 0, 2, 2, 2, voxels );
+		assertArrayEquals( new float[] { 0, 1, 2, 3, 4, 5, 6, 7 }, voxels, 0 );
+	}
+
+	@Test
+	public void testGetVoxelsChannel()
+	{
+		final ImageStack stack = TestVirtualStack.ints( 1, 1, new int[][] { { 0xff010203 } } );
+		assertArrayEquals( new float[] { 1 }, stack.getVoxels( 0, 0, 0, 1, 1, 1, null, 0 ), 0 );
+		assertArrayEquals( new float[] { 2 }, stack.getVoxels( 0, 0, 0, 1, 1, 1, null, 1 ), 0 );
+		assertArrayEquals( new float[] { 3 }, stack.getVoxels( 0, 0, 0, 1, 1, 1, null, 2 ), 0 );
+	}
+
+	@Test
+	public void testGetVoxelsSubVolume()
+	{
+		int[][] pixels = { range( 0, 99 ), range( 100, 199 ), range( 200, 299 ), range( 300, 399 ) };
+		final ImageStack stack = TestVirtualStack.ints( 10, 10, pixels );
+		float[] voxels = stack.getVoxels( 1, 1, 1, 2, 2, 2, null );
+		assertArrayEquals( new float[] { 111, 112, 121, 122, 211, 212, 221, 222 }, voxels, 0 );
+	}
+
+	private int[] range( int start, int end )
+	{
+		return IntStream.rangeClosed( start, end ).toArray();
+	}
+
+	@Test
+	public void testSetVoxels()
+	{
+		byte[][] pixels = { { 0 } };
+		ImageStack stack = TestVirtualStack.bytes( 1, 1, pixels );
+		stack.setVoxels( 0, 0, 0, 1, 1, 1, new float[] { 42 } );
+		assertEquals( 42, pixels[ 0 ][ 0 ] );
+	}
+
+	@Test
+	public void testSetVoxelsARGB()
+	{
+		int[][] pixels = { { 0 } };
+		ImageStack stack = TestVirtualStack.ints( 1, 1, pixels );
+		stack.setVoxels( 0, 0, 0, 1, 1, 1, new float[] { 42 } );
+		assertEquals( 42, pixels[ 0 ][ 0 ] );
+	}
+
+	@Test
+	public void testSetVoxelsChannel()
+	{
+		int[][] pixels = { { 0 } };
+		ImageStack stack = TestVirtualStack.ints( 1, 1, pixels );
+		stack.setVoxels( 0, 0, 0, 1, 1, 1, new float[] { 1 }, 0 );
+		stack.setVoxels( 0, 0, 0, 1, 1, 1, new float[] { 2 }, 1 );
+		stack.setVoxels( 0, 0, 0, 1, 1, 1, new float[] { 3 }, 2 );
+		assertEquals( 0x010203, pixels[ 0 ][ 0 ] );
+	}
+
+	@Test
+	public void testSetVoxelsSubVolume()
+	{
+		byte[][] pixels = { { 1, 2, 3, 4 }, { 5, 6, 7, 8 } };
+		byte[][] expected = { { 1, 2, 13, 4 }, { 5, 6, 17, 8 } };
+		float[] voxels = { 13, 17 };
+		ImageStack stack = TestVirtualStack.bytes( 2, 2, pixels );
+		stack.setVoxels( 0, 1, 0, 1, 1, 2, voxels );
+		assertTrue( Arrays.deepEquals( expected, pixels ) );
+	}
+
+	@Test( expected = IndexOutOfBoundsException.class )
+	public void testOutOfBounds()
+	{
+		final ImageStack stack = TestVirtualStack.bytes( 1, 1, new byte[ 1 ][ 4 ] );
+		stack.getVoxels( 0, 0, 0, 1, 2, 1, null );
+	}
+
+	private static class TestVirtualStack extends AbstractVirtualStack
+	{
+
+		private final Object[] pixels;
+
+		private TestVirtualStack( int width, int height, Object[] pixels, int bitDepth )
+		{
+			super( width, height, pixels.length, bitDepth );
+			this.pixels = pixels;
+		}
+
+		public static TestVirtualStack bytes( int width, int height, byte[][] pixels )
+		{
+			return new TestVirtualStack( width, height, pixels, 8 );
+		}
+
+		public static TestVirtualStack ints( int width, int height, int[][] pixels )
+		{
+			return new TestVirtualStack( width, height, pixels, 24 );
+		}
+
+		@Override
+		protected Object getPixelsZeroBasedIndex( int index )
+		{
+			return pixels[ index ];
+		}
+
+		@Override
+		protected void setPixelsZeroBasedIndex( int index, Object pixels )
+		{
+			this.pixels[ index ] = pixels;
+		}
+	}
+}

--- a/src/test/java/net/imglib2/img/display/imagej/AbstractVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/AbstractVirtualStackTest.java
@@ -7,6 +7,8 @@ import ij.VirtualStack;
 import ij.gui.Roi;
 import ij.plugin.Resizer;
 import ij.process.ByteProcessor;
+import ij.process.FloatProcessor;
+import ij.process.ImageProcessor;
 import org.junit.Test;
 
 import java.awt.*;
@@ -157,6 +159,32 @@ public class AbstractVirtualStackTest
 		VirtualStack stack = new TestVirtualStack( 1, 1, 1, pixels );
 		stack.setPixels( new byte[] { 42 }, 1 );
 		assertEquals( 42, pixels[ 0 ][ 0 ] );
+	}
+
+	@Test
+	public void testSetProcessor()
+	{
+		byte[][] pixels = new byte[ 1 ][ 1 ];
+		VirtualStack stack = new TestVirtualStack( 1, 1, 1, pixels );
+		final ImageProcessor processor = new ByteProcessor( 1, 1, new byte[] { 42 } );
+		stack.setProcessor( processor, 1 );
+		assertEquals( 42, pixels[ 0 ][ 0 ] );
+	}
+
+	@Test( expected = IllegalArgumentException.class )
+	public void testSetProcessorWrongSize()
+	{
+		VirtualStack stack = new TestVirtualStack( 1, 1, 1, new byte[ 1 ][ 1 ] );
+		final ImageProcessor processor = new ByteProcessor( 2, 1, new byte[ 2 ] );
+		stack.setProcessor( processor, 1 );
+	}
+
+	@Test( expected = IllegalArgumentException.class )
+	public void testSetProcessorWrongType()
+	{
+		VirtualStack stack = new TestVirtualStack( 1, 1, 1, new byte[ 1 ][ 1 ] );
+		final ImageProcessor processor = new FloatProcessor( 1, 1, new float[ 1 ] );
+		stack.setProcessor( processor, 1 );
 	}
 
 	@Test

--- a/src/test/java/net/imglib2/img/display/imagej/AbstractVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/AbstractVirtualStackTest.java
@@ -3,8 +3,10 @@ package net.imglib2.img.display.imagej;
 import ij.IJ;
 import ij.ImagePlus;
 import ij.ImageStack;
+import ij.VirtualStack;
 import ij.gui.Roi;
 import ij.plugin.Resizer;
+import ij.process.ByteProcessor;
 import org.junit.Test;
 
 import java.awt.*;
@@ -148,6 +150,27 @@ public class AbstractVirtualStackTest
 		return result;
 	}
 
+	@Test
+	public void testSetPixels()
+	{
+		byte[][] pixels = new byte[ 1 ][ 1 ];
+		VirtualStack stack = new TestVirtualStack( 1, 1, 1, pixels );
+		stack.setPixels( new byte[] { 42 }, 1 );
+		assertEquals( 42, pixels[ 0 ][ 0 ] );
+	}
+
+	@Test
+	public void testWriteProtection()
+	{
+		byte[][] pixels = new byte[ 1 ][ 1 ];
+		// NB: use non writable stack
+		VirtualStack stack = new TestReadonlyVirtualStack( 1, 1, 1, pixels );
+		stack.setPixels( new byte[] { 42 }, 1 );
+		stack.setProcessor( new ByteProcessor( 1, 1, new byte[] { 43 } ), 1 );
+		stack.setVoxels( 0, 0, 0, 1, 1, 1, new float[] { 44 } );
+		assertEquals( 0, pixels[ 0 ][ 0 ] );
+	}
+
 	private static class TestVirtualStack extends AbstractVirtualStack
 	{
 
@@ -171,4 +194,20 @@ public class AbstractVirtualStackTest
 			this.pixels[ index ] = ( byte[] ) pixels;
 		}
 	}
+
+	private static class TestReadonlyVirtualStack extends TestVirtualStack
+	{
+
+		public TestReadonlyVirtualStack( int width, int height, int size, byte[][] pixels )
+		{
+			super( width, height, size, pixels );
+		}
+
+		@Override
+		protected boolean isWritable()
+		{
+			return false;
+		}
+	}
+
 }

--- a/src/test/java/net/imglib2/img/display/imagej/ImageJVirtualStackGetProcessorBenchmark.java
+++ b/src/test/java/net/imglib2/img/display/imagej/ImageJVirtualStackGetProcessorBenchmark.java
@@ -1,0 +1,128 @@
+/*-
+ * #%L
+ * ImgLib2: a general-purpose, multidimensional image processing library.
+ * %%
+ * Copyright (C) 2009 - 2018 Tobias Pietzsch, Stephan Preibisch, Stephan Saalfeld,
+ * John Bogovic, Albert Cardona, Barry DeZonia, Christian Dietz, Jan Funke,
+ * Aivar Grislis, Jonathan Hale, Grant Harris, Stefan Helfrich, Mark Hiner,
+ * Martin Horn, Steffen Jaensch, Lee Kamentsky, Larry Lindsey, Melissa Linkert,
+ * Mark Longair, Brian Northan, Nick Perry, Curtis Rueden, Johannes Schindelin,
+ * Jean-Yves Tinevez and Michael Zinsmaier.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.img.display.imagej;
+
+import ij.ImageStack;
+import net.imagej.ImgPlus;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgFactory;
+import net.imglib2.type.NativeType;
+import net.imglib2.type.numeric.ARGBType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.DoubleType;
+import net.imglib2.type.numeric.real.FloatType;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+@State( Scope.Benchmark )
+public class ImageJVirtualStackGetProcessorBenchmark
+{
+
+	private final ConcurrentMap< Object, Img<?> > cache = new ConcurrentHashMap<>();
+
+	private < T extends NativeType<T> > Img< T > getImage(T type) {
+		return ( Img< T > ) cache.computeIfAbsent( type, ignore -> new ArrayImgFactory<>( type ).create( 200, 200, 200 ) );
+	}
+
+	@Benchmark
+	public void bytes() {
+		test( new UnsignedByteType() );
+	}
+
+	@Benchmark
+	public void shorts() {
+		test( new UnsignedShortType() );
+	}
+
+	@Benchmark
+	public void floats() {
+		test( new FloatType() );
+	}
+
+	@Benchmark
+	public void doubles() {
+		test( new DoubleType() );
+	}
+
+	@Benchmark
+	public void ints() {
+		test( new DoubleType() );
+	}
+
+	@Benchmark
+	public void argbs() {
+		test( new ARGBType() );
+	}
+
+	@Benchmark
+	public void all() {
+		test( new UnsignedByteType() );
+		test( new UnsignedShortType() );
+		test( new FloatType() );
+		test( new ARGBType() );
+	}
+
+	private < T extends NativeType< T > > void test( T type )
+	{
+		Img< T > image = getImage( type );
+		ImageStack stack = ImgToVirtualStack.wrap( new ImgPlus<>( image ) ).getStack();
+		for ( int i = 0; i < stack.getSize(); i++ )
+		{
+			stack.getProcessor( i + 1 );
+		}
+	}
+
+	public static void main( final String... args ) throws RunnerException
+	{
+		final Options opt = new OptionsBuilder()
+				.include( ImageJVirtualStackGetProcessorBenchmark.class.getSimpleName() )
+				.forks( 0 )
+				.warmupIterations( 4 )
+				.measurementIterations( 8 )
+				.warmupTime( TimeValue.milliseconds( 100 ) )
+				.measurementTime( TimeValue.milliseconds( 100 ) )
+				.build();
+		new Runner( opt ).run();
+	}
+}

--- a/src/test/java/net/imglib2/img/display/imagej/ImageJVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/ImageJVirtualStackTest.java
@@ -69,7 +69,7 @@ public class ImageJVirtualStackTest
 	{
 		// NB: ColorModel can cause troubles when using a ColorProcessor so try to create one
 		final Img< ARGBType > img = ArrayImgs.argbs( 1, 1 );
-		final ImageStack stackARGB = new ImageJVirtualStackARGB<>( img, ( i, o ) -> o.set( i.get() ) );
+		final ImageStack stackARGB = ImageJVirtualStackARGB.wrap( img );
 		final ImagePlus imagePlus = new ImagePlus( "title", stackARGB );
 		final ImageStack stack = imagePlus.getStack();
 		assertTrue( stack.getProcessor( 1 ) instanceof ColorProcessor );
@@ -79,7 +79,7 @@ public class ImageJVirtualStackTest
 	public void test()
 	{
 		final Img< UnsignedByteType > img = RandomImgs.randomImage( new UnsignedByteType(), 1000, 1000, 10 );
-		final VirtualStack vs = new ImageJVirtualStackUnsignedByte<>( img, copyConverter() );
+		final VirtualStack vs = ImageJVirtualStackUnsignedByte.wrap( img );
 		final RandomAccess< UnsignedByteType > randomAccess = img.randomAccess();
 		for ( int z = 0; z < 10; z++ )
 		{
@@ -106,7 +106,7 @@ public class ImageJVirtualStackTest
 	private VirtualStack example()
 	{
 		final Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( new byte[] { 1, 2, 3, 4, 5, 6 }, 3, 1, 2 );
-		return new ImageJVirtualStackUnsignedByte<>( img, copyConverter() );
+		return ImageJVirtualStackUnsignedByte.wrap( img );
 	}
 
 	@Test
@@ -155,7 +155,7 @@ public class ImageJVirtualStackTest
 	public void testFloatProcessor()
 	{
 		final float value = 42f;
-		final VirtualStack vs = new ImageJVirtualStackFloat<>( ArrayImgs.floats( new float[] { value }, 1, 1, 1 ), copyConverter() );
+		final VirtualStack vs = ImageJVirtualStackFloat.wrap( ArrayImgs.floats( new float[] { value }, 1, 1, 1 ) );
 		final ImageProcessor processor = vs.getProcessor( 1 );
 		assertTrue( processor instanceof FloatProcessor );
 		assertEquals( value, processor.getf( 0, 0 ), 0f );
@@ -165,7 +165,7 @@ public class ImageJVirtualStackTest
 	public void testShortProcessor()
 	{
 		final short value = 13;
-		final VirtualStack vs = new ImageJVirtualStackUnsignedShort<>( ArrayImgs.unsignedShorts( new short[] { value }, 1, 1, 1 ), copyConverter() );
+		final VirtualStack vs = ImageJVirtualStackUnsignedShort.wrap( ArrayImgs.unsignedShorts( new short[] { value }, 1, 1, 1 ) );
 		final ImageProcessor processor = vs.getProcessor( 1 );
 		assertTrue( processor instanceof ShortProcessor );
 		assertEquals( value, processor.get( 0, 0 ) );
@@ -175,7 +175,7 @@ public class ImageJVirtualStackTest
 	public void testProcessor()
 	{
 		final int value = 43;
-		final VirtualStack vs = new ImageJVirtualStackARGB<>( ArrayImgs.argbs( new int[] { value }, 1, 1, 1 ), copyConverter() );
+		final VirtualStack vs = ImageJVirtualStackARGB.wrap( ArrayImgs.argbs( new int[] { value }, 1, 1, 1 ) );
 		final ImageProcessor processor = vs.getProcessor( 1 );
 		assertTrue( processor instanceof ColorProcessor );
 		assertEquals( value, processor.get( 0, 0 ) & 0x00ffffff );
@@ -201,7 +201,6 @@ public class ImageJVirtualStackTest
 		assertEquals( value, image.firstElement().get() );
 	}
 
-	@Ignore("not working yet")
 	@Test
 	public void testSetPixelsARGB() {
 		final Img< ARGBType > image = ArrayImgs.argbs( 1, 1, 1 );
@@ -220,11 +219,6 @@ public class ImageJVirtualStackTest
 		vs.setWritable( true );
 		vs.setPixels( new float[] { value }, 1 );
 		assertEquals( value, image.firstElement().get(), 0 );
-	}
-
-	private < T extends Type< T > > Converter< T, T > copyConverter()
-	{
-		return ( i, o ) -> o.set( i );
 	}
 
 	@Test

--- a/src/test/java/net/imglib2/img/display/imagej/ImageJVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/ImageJVirtualStackTest.java
@@ -236,9 +236,9 @@ public class ImageJVirtualStackTest
 	public void testSetVoxels() {
 		// NB: this tests ImageJVirtualStack getSliceZeroBasedIndex
 		Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( 1, 1 );
-		final ImageStack stack = ImageJVirtualStackUnsignedByte.wrap( img );
-		float[] voxels = { 42 };
-		stack.setVoxels( 0, 0, 0, 1, 1, 1, voxels );
+		final ImageJVirtualStack<?> stack = ImageJVirtualStackUnsignedByte.wrap( img );
+		stack.setWritable( true );
+		stack.setVoxels( 0, 0, 0, 1, 1, 1, new float[] { 42 } );
 		assertEquals( 42, img.firstElement().get() );
 	}
 

--- a/src/test/java/net/imglib2/img/display/imagej/ImageJVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/ImageJVirtualStackTest.java
@@ -48,6 +48,9 @@ import net.imglib2.type.Type;
 import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 
+import net.imglib2.type.numeric.integer.UnsignedShortType;
+import net.imglib2.type.numeric.real.FloatType;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import ij.ImagePlus;
@@ -176,6 +179,47 @@ public class ImageJVirtualStackTest
 		final ImageProcessor processor = vs.getProcessor( 1 );
 		assertTrue( processor instanceof ColorProcessor );
 		assertEquals( value, processor.get( 0, 0 ) & 0x00ffffff );
+	}
+
+	@Test
+	public void testSetPixelsBytes() {
+		final Img< UnsignedByteType > image = ArrayImgs.unsignedBytes( 1, 1, 1 );
+		final ImageJVirtualStack vs = ImageJVirtualStackUnsignedByte.wrap( image );
+		byte value = 42;
+		vs.setWritable( true );
+		vs.setPixels( new byte[] { value }, 1 );
+		assertEquals( value, image.firstElement().get() );
+	}
+
+	@Test
+	public void testSetPixelsShort() {
+		final Img< UnsignedShortType > image = ArrayImgs.unsignedShorts( 1, 1, 1 );
+		final ImageJVirtualStack vs = ImageJVirtualStackUnsignedShort.wrap( image );
+		short value = 42;
+		vs.setWritable( true );
+		vs.setPixels( new short[] { value }, 1 );
+		assertEquals( value, image.firstElement().get() );
+	}
+
+	@Ignore("not working yet")
+	@Test
+	public void testSetPixelsARGB() {
+		final Img< ARGBType > image = ArrayImgs.argbs( 1, 1, 1 );
+		final ImageJVirtualStack vs = ImageJVirtualStackARGB.wrap( image );
+		int value = 42;
+		vs.setWritable( true );
+		vs.setPixels( new int[] { value }, 1 );
+		assertEquals( value, image.firstElement().get() );
+	}
+
+	@Test
+	public void testSetPixelsFloat() {
+		final Img< FloatType > image = ArrayImgs.floats( 1, 1, 1 );
+		final ImageJVirtualStack vs = ImageJVirtualStackFloat.wrap( image );
+		float value = 42;
+		vs.setWritable( true );
+		vs.setPixels( new float[] { value }, 1 );
+		assertEquals( value, image.firstElement().get(), 0 );
 	}
 
 	private < T extends Type< T > > Converter< T, T > copyConverter()

--- a/src/test/java/net/imglib2/img/display/imagej/ImageJVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/ImageJVirtualStackTest.java
@@ -42,6 +42,7 @@ import static org.junit.Assert.assertTrue;
 import net.imglib2.RandomAccess;
 import net.imglib2.converter.Converter;
 import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImg;
 import net.imglib2.img.array.ArrayImgs;
 import net.imglib2.test.RandomImgs;
 import net.imglib2.type.Type;
@@ -219,6 +220,26 @@ public class ImageJVirtualStackTest
 		vs.setWritable( true );
 		vs.setPixels( new float[] { value }, 1 );
 		assertEquals( value, image.firstElement().get(), 0 );
+	}
+
+	@Test
+	public void testGetVoxels5DStack() {
+		// NB: this tests ImageJVirtualStack getSliceZeroBasedIndex
+		Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( new byte[] { 0, 1, 2, 3, 4, 5, 6, 7 }, 1, 1, 2, 2, 2 );
+		final ImageStack stack = ImageJVirtualStackUnsignedByte.wrap( img );
+		float[] voxels = new float[8];
+		stack.getVoxels( 0, 0, 0, 1, 1, 8, voxels );
+		assertArrayEquals( new float[] { 0, 1, 2, 3, 4, 5, 6, 7 }, voxels, 0);
+	}
+
+	@Test
+	public void testSetVoxels() {
+		// NB: this tests ImageJVirtualStack getSliceZeroBasedIndex
+		Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( 1, 1 );
+		final ImageStack stack = ImageJVirtualStackUnsignedByte.wrap( img );
+		float[] voxels = { 42 };
+		stack.setVoxels( 0, 0, 0, 1, 1, 1, voxels );
+		assertEquals( 42, img.firstElement().get() );
 	}
 
 	@Test

--- a/src/test/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStackTest.java
+++ b/src/test/java/net/imglib2/img/display/imagej/PlanarImgToVirtualStackTest.java
@@ -45,9 +45,11 @@ import net.imagej.axis.Axes;
 import net.imagej.axis.AxisType;
 import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.img.basictypeaccess.array.FloatArray;
+import net.imglib2.img.basictypeaccess.array.IntArray;
 import net.imglib2.img.planar.PlanarImg;
 import net.imglib2.img.planar.PlanarImgFactory;
 import net.imglib2.img.planar.PlanarImgs;
+import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.IntegerType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
 import net.imglib2.type.numeric.real.FloatType;
@@ -144,5 +146,17 @@ public class PlanarImgToVirtualStackTest
 		imagePlus.getStack().setPixels( new float[] { expected }, 1 );
 		// test
 		assertEquals( expected, img.cursor().next().get(), 0.0f );
+	}
+
+	@Test
+	public void testGetProcessorForColorProcessor() {
+		// NB: Test that the underlying data does not change, when a ColorProcessor is created.
+		// To achieve this min and max must not be set for ColorProcessor.
+		final PlanarImg< ARGBType, IntArray > argbs = PlanarImgs.argbs( 1, 1, 1 );
+		argbs.randomAccess().get().set( 0xff010203 );
+		final VirtualStack stack = PlanarImgToVirtualStack.wrap( argbs );
+		assertArrayEquals( new int[] { 0xff010203 }, (int[]) stack.getPixels( 1 ) );
+		stack.getProcessor( 1 );
+		assertArrayEquals( new int[] { 0xff010203 }, (int[]) stack.getPixels( 1 ) );
 	}
 }


### PR DESCRIPTION
This PR fixes issue #27.

That means ImageJVirtualStack now implement getVoxels and setVoxels.

Additionally:
* A bug when using AbstractVirtualStack with ColorProcessor is fixed.
* Pixel type conversion in ImageJVirtualStack is cleaned up, this fixes #16. Previously ImageJVirtualStack used Converters. Which was very tricky because this only worked for reading but ImageJVirtualStack also supports writing. Now SamplerConverters are used instead.