### PR TITLE
Add wrapInt to ImagePlusAdapter and VirtualStackAdapter

### DIFF
--- a/src/main/java/net/imglib2/img/ImagePlusAdapter.java
+++ b/src/main/java/net/imglib2/img/ImagePlusAdapter.java
@@ -52,6 +52,7 @@ import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.ComplexType;
 import net.imglib2.type.numeric.NumericType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.type.numeric.real.FloatType;
 
@@ -173,6 +174,22 @@ public class ImagePlusAdapter
 
 		// create a Type that is linked to the container
 		final UnsignedShortType linkedType = new UnsignedShortType( container );
+
+		// pass it to the DirectAccessContainer
+		container.setLinkedType( linkedType );
+
+		return container;
+	}
+
+	public static IntImagePlus< UnsignedIntType > wrapInt( final ImagePlus imp )
+	{
+		if( imp.getType() != ImagePlus.COLOR_RGB )
+			return null;
+
+		final IntImagePlus< UnsignedIntType > container = new IntImagePlus<>( imp );
+
+		// create a Type that is linked to the container
+		final UnsignedIntType linkedType = new UnsignedIntType( container );
 
 		// pass it to the DirectAccessContainer
 		container.setLinkedType( linkedType );

--- a/src/main/java/net/imglib2/img/VirtualStackAdapter.java
+++ b/src/main/java/net/imglib2/img/VirtualStackAdapter.java
@@ -54,6 +54,7 @@ import net.imglib2.type.NativeType;
 import net.imglib2.type.NativeTypeFactory;
 import net.imglib2.type.numeric.ARGBType;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.integer.UnsignedIntType;
 import net.imglib2.type.numeric.integer.UnsignedShortType;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.Fraction;
@@ -99,6 +100,17 @@ public class VirtualStackAdapter
 	public static ImgPlus< FloatType > wrapFloat( final ImagePlus image )
 	{
 		return internWrap( image, ImagePlus.GRAY32, new FloatType(), array -> new FloatArray( ( float[] ) array ) );
+	}
+
+	/**
+	 * Wraps a 32 bit {@link ImagePlus}, into an {@link ImgPlus}, that is backed
+	 * by a {@link PlanarImg}. The {@link PlanarImg} loads the planes only if
+	 * needed, and caches them. The axes of the returned image are set according
+	 * to the calibration of the given image.
+	 */
+	public static ImgPlus< UnsignedIntType > wrapInt( final ImagePlus image )
+	{
+		return internWrap( image, ImagePlus.COLOR_RGB, new UnsignedIntType(), array -> new IntArray( ( int[] ) array ) );
 	}
 
 	/**


### PR DESCRIPTION
32-bit int images are available in ImageJ1 as an extension of the ColorProcessor:
https://forum.image.sc/t/feature-request-32-bit-int-image-in-imagej1/45493/5

This pull request adds methods to interface with 32-bit images by adding `wrapInt` methods to `ImagePlusAdapter` and `VirtualStackAdapter`.