### PR TITLE
New public method ImageJVirtualStack.getSource returning the underlying RandomAccessibleInterval

### DIFF
--- a/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
+++ b/src/main/java/net/imglib2/img/display/imagej/ImageJVirtualStack.java
@@ -222,4 +222,10 @@ public class ImageJVirtualStack< T extends NativeType< T > > extends AbstractVir
 		}
 		return origin;
 	}
+
+	/** Get the underlying ImgLib2 {@link RandomAccessibleInterval}. */
+	public RandomAccessibleInterval< T > getSource()
+	{
+		return source;
+	}
 }


### PR DESCRIPTION
There are many occasions when one wants to get the underlying RandomAccessibleInterval. Offering a public method to return the private field "source" addresses this well, so one can write, for example:

RandomAccessibleInterval<UnsignedShortType> rai = IJ.getImage().getStack().getSource();

Or more simply from a script:

rai = IJ.getImage().getStack().getSource()